### PR TITLE
Port alignment filter node to C++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,17 +152,20 @@ add_library(navsat_transform src/navsat_transform.cpp)
 add_library(ekf_localization_nodelet src/ekf_localization_nodelet.cpp)
 add_library(ukf_localization_nodelet src/ukf_localization_nodelet.cpp)
 add_library(navsat_transform_nodelet src/navsat_transform_nodelet.cpp)
+add_library(se3_algorithms src/se3_algorithms.cpp)
 
 # Executables
 add_executable(ekf_localization_node src/ekf_localization_node.cpp)
 add_executable(ukf_localization_node src/ukf_localization_node.cpp)
 add_executable(navsat_transform_node src/navsat_transform_node.cpp)
 add_executable(robot_localization_listener_node src/robot_localization_listener_node.cpp)
+add_executable(alignment_filter_node src/alignment_filter_node.cpp)
 
 # Dependencies
 add_dependencies(filter_base ${PROJECT_NAME}_gencpp)
 add_dependencies(navsat_transform ${PROJECT_NAME}_gencpp)
 add_dependencies(robot_localization_listener_node ${PROJECT_NAME}_gencpp)
+add_dependencies(alignment_filter_node ${PROJECT_NAME}_gencpp)
 
 # Linking
 target_link_libraries(ros_filter_utilities ${catkin_LIBRARIES} ${EIGEN3_LIBRARIES})
@@ -182,6 +185,8 @@ target_link_libraries(ukf_localization_nodelet ros_filter ${catkin_LIBRARIES})
 target_link_libraries(navsat_transform filter_utilities ros_filter_utilities ${catkin_LIBRARIES} ${EIGEN3_LIBRARIES} ${GeographicLib_LIBRARIES})
 target_link_libraries(navsat_transform_node navsat_transform ${catkin_LIBRARIES} ${GeographicLib_LIBRARIES})
 target_link_libraries(navsat_transform_nodelet navsat_transform ${catkin_LIBRARIES} ${GeographicLib_LIBRARIES})
+target_link_libraries(se3_algorithms ${catkin_LIBRARIES} ${EIGEN3_LIBRARIES})
+target_link_libraries(alignment_filter_node se3_algorithms ${catkin_LIBRARIES} ${EIGEN3_LIBRARIES})
 
 #############
 ## Install ##
@@ -201,6 +206,7 @@ install(TARGETS
   ros_robot_localization_listener
   ukf
   ukf_localization_nodelet
+  se3_algorithms
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})
@@ -210,6 +216,7 @@ install(TARGETS
   navsat_transform_node
   robot_localization_listener_node
   ukf_localization_node
+  alignment_filter_node
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
 ## Mark cpp header files for installation

--- a/include/ais_robot_localization/se3_algorithms.h
+++ b/include/ais_robot_localization/se3_algorithms.h
@@ -1,0 +1,35 @@
+#ifndef AIS_ROBOT_LOCALIZATION_SE3_ALGORITHMS_H
+#define AIS_ROBOT_LOCALIZATION_SE3_ALGORITHMS_H
+
+#include <Eigen/Dense>
+#include <geometry_msgs/Pose.h>
+#include <geometry_msgs/PoseStamped.h>
+#include <vector>
+#include <string>
+
+namespace ais_robot_localization
+{
+
+// Convert ROS pose to Eigen Isometry3d
+Eigen::Isometry3d odomToSe3(const geometry_msgs::Pose& pose);
+
+// Convert Eigen Isometry3d to PoseStamped
+geometry_msgs::PoseStamped se3ToPoseStamped(const Eigen::Isometry3d& se3,
+                                            const ros::Time& stamp,
+                                            const std::string& frame_id,
+                                            bool z_to_zero = false);
+
+// Weighted Kabsch-based alignment with snake pre-processing
+Eigen::Isometry3d snakeAlignment(const std::vector<Eigen::Isometry3d>& trajectory,
+                                 const std::vector<Eigen::Isometry3d>& reference,
+                                 const std::vector<double>& weights);
+
+// Gaussian weighting helper
+std::vector<double> gaussianWeight(const std::vector<double>& errors, double half_life);
+
+// Euclidean distance helper for geometry_msgs::Pose
+double euclideanDistance(const geometry_msgs::Pose& a, const geometry_msgs::Pose& b);
+
+}  // namespace ais_robot_localization
+
+#endif  // AIS_ROBOT_LOCALIZATION_SE3_ALGORITHMS_H

--- a/launch/alignment_filter_geo_kombi_no_tf.launch
+++ b/launch/alignment_filter_geo_kombi_no_tf.launch
@@ -2,7 +2,7 @@
     <rosparam command="load" file="$(find ais_robot_localization)/params/alignment_filter_geo_kombi_no_tf.yaml" />
 
 
-    <node name="alignment_filter" pkg="ais_robot_localization" type="alignment_filter_node.py" output="screen">     
+    <node name="alignment_filter" pkg="ais_robot_localization" type="alignment_filter_node" output="screen">
         <remap from="/local_odom" to="/localization/odometry/odom_lidar"/>
         <remap from="/alignment_odometry" to="/localization/alignment_filter/odom_map"/>
         <remap from="/alignment_global_path" to="/localization/alignment_filter/global_path"/>

--- a/launch/alignment_filter_geo_kombi_standard.launch
+++ b/launch/alignment_filter_geo_kombi_standard.launch
@@ -2,7 +2,7 @@
     <rosparam command="load" file="$(find ais_robot_localization)/params/alignment_filter_geo_kombi_standard.yaml" />
 
 
-    <node name="alignment_filter" pkg="ais_robot_localization" type="alignment_filter_node.py" output="screen">     
+    <node name="alignment_filter" pkg="ais_robot_localization" type="alignment_filter_node" output="screen">
         <remap from="/local_odom" to="/localization/odometry/odom_lidar"/>
         <remap from="/alignment_odometry" to="/localization/alignment_filter/odom_map"/>
         <remap from="/alignment_global_path" to="/localization/alignment_filter/global_path"/>

--- a/launch/alignment_filter_sim.launch
+++ b/launch/alignment_filter_sim.launch
@@ -2,7 +2,7 @@
     <rosparam command="load" file="$(find ais_robot_localization)/params/alignment_filter_geo_kombi_standard.yaml" />
 
 
-    <node name="alignment_filter" pkg="ais_robot_localization" type="alignment_filter_node.py" output="screen">     
+    <node name="alignment_filter" pkg="ais_robot_localization" type="alignment_filter_node" output="screen">
         <remap from="/local_odom" to="/localization/odometry/odom_lidar"/>
         <remap from="/alignment_odometry" to="/localization/alignment_filter/odom_map"/>
         <remap from="/alignment_global_path" to="/localization/alignment_filter/global_path"/>

--- a/src/alignment_filter_node.cpp
+++ b/src/alignment_filter_node.cpp
@@ -1,0 +1,257 @@
+#include <ros/ros.h>
+#include <nav_msgs/Odometry.h>
+#include <nav_msgs/Path.h>
+#include <geometry_msgs/TransformStamped.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2_ros/transform_broadcaster.h>
+#include <tf2_ros/transform_listener.h>
+#include <std_msgs/Float32MultiArray.h>
+#include <ais_robot_localization/LocalizationMonitorResult.h>
+
+#include <vector>
+#include <algorithm>
+#include <numeric>
+#include <mutex>
+
+#include "ais_robot_localization/se3_algorithms.h"
+
+namespace arl = ais_robot_localization;
+
+class AlignmentFilterNode
+{
+public:
+  AlignmentFilterNode()
+      : nh_(),
+        nh_private_("~"),
+        publish_tf_(true),
+        current_transform_(Eigen::Isometry3d::Identity()),
+        used_length_(0.0)
+  {
+    nh_private_.param("publish_tf", publish_tf_, true);
+
+    if (publish_tf_)
+    {
+      tf_listener_ = std::make_shared<tf2_ros::TransformListener>(tf_buffer_);
+      timer_ = nh_.createTimer(ros::Duration(0.2), &AlignmentFilterNode::publishTransform, this);
+    }
+
+    global_path_pub_ = nh_.advertise<nav_msgs::Path>("/alignment_global_path", 10);
+    local_path_transformed_pub_ = nh_.advertise<nav_msgs::Path>("/alignment_local_path_transformed", 10);
+    odom_pub_ = nh_.advertise<nav_msgs::Odometry>("/alignment_odometry", 10);
+
+    sub_ = nh_.subscribe("/localization_result", 10, &AlignmentFilterNode::localizationCallback, this);
+    local_odom_sub_ = nh_.subscribe("/local_odom", 10, &AlignmentFilterNode::localOdomCallback, this);
+
+    global_frame_ = "map";
+    local_frame_ = "odom";
+  }
+
+private:
+  void publishTransform(const ros::TimerEvent&)
+  {
+    std::lock_guard<std::recursive_mutex> lock(mutex_);
+    if (!publish_tf_)
+    {
+      return;
+    }
+
+    try
+    {
+      geometry_msgs::TransformStamped latest_tf = tf_buffer_.lookupTransform(local_frame_, "base_link", ros::Time(0),
+                                                                             ros::Duration(1.0));
+      geometry_msgs::TransformStamped t;
+      t.header.stamp = latest_tf.header.stamp;
+      t.header.frame_id = global_frame_;
+      t.child_frame_id = local_frame_;
+      Eigen::Quaterniond q(current_transform_.rotation());
+      Eigen::Vector3d trans = current_transform_.translation();
+      t.transform.translation.x = trans.x();
+      t.transform.translation.y = trans.y();
+      t.transform.translation.z = trans.z();
+      t.transform.rotation.x = q.x();
+      t.transform.rotation.y = q.y();
+      t.transform.rotation.z = q.z();
+      t.transform.rotation.w = q.w();
+      tf_broadcaster_.sendTransform(t);
+    }
+    catch (const tf2::TransformException& ex)
+    {
+      ROS_ERROR_STREAM("Error publishing transform: " << ex.what());
+    }
+  }
+
+  void localOdomCallback(const nav_msgs::Odometry::ConstPtr& odom_msg)
+  {
+    std::lock_guard<std::recursive_mutex> lock(mutex_);
+    Eigen::Isometry3d pose = arl::odomToSe3(odom_msg->pose.pose);
+    Eigen::Isometry3d transformed = current_transform_ * pose;
+
+    nav_msgs::Odometry transformed_odom = *odom_msg;
+    transformed_odom.header.frame_id = global_frame_;
+    Eigen::Quaterniond q(transformed.rotation());
+    transformed_odom.pose.pose.position.x = transformed.translation().x();
+    transformed_odom.pose.pose.position.y = transformed.translation().y();
+    transformed_odom.pose.pose.position.z = transformed.translation().z();
+    transformed_odom.pose.pose.orientation.x = q.x();
+    transformed_odom.pose.pose.orientation.y = q.y();
+    transformed_odom.pose.pose.orientation.z = q.z();
+    transformed_odom.pose.pose.orientation.w = q.w();
+    // set fixed covariance like python implementation
+    double cov[36] = {1.0, 0, 0, 0, 0, 0,
+                      0, 1.0, 0, 0, 0, 0,
+                      0, 0, 1.0, 0, 0, 0,
+                      0, 0, 0, 0.1, 0, 0,
+                      0, 0, 0, 0, 0.1, 0,
+                      0, 0, 0, 0, 0, 0.1};
+    std::copy(std::begin(cov), std::end(cov), transformed_odom.pose.covariance.begin());
+    current_odom_state_ = transformed_odom;
+    odom_pub_.publish(transformed_odom);
+  }
+
+  void localizationCallback(const ais_robot_localization::LocalizationMonitorResult::ConstPtr& msg)
+  {
+    std::lock_guard<std::recursive_mutex> lock(mutex_);
+    if (global_frame_.empty())
+    {
+      global_frame_ = msg->pose_global.header.frame_id;
+    }
+    if (local_frame_.empty())
+    {
+      local_frame_ = msg->pose_local.header.frame_id;
+    }
+
+    data_list_.push_back(*msg);
+
+    global_path_.poses.push_back(msg->pose_global);
+    global_poses_.push_back(arl::odomToSe3(msg->pose_global.pose));
+    time_stamps_.push_back(msg->pose_global.header.stamp);
+
+    local_path_.poses.push_back(msg->pose_local);
+    local_poses_.push_back(arl::odomToSe3(msg->pose_local.pose));
+
+    if (!msg->float_array.data.empty())
+    {
+      error_trans_avg_.push_back(msg->float_array.data[0]);
+    }
+    else
+    {
+      error_trans_avg_.push_back(0.0);
+    }
+    distances_current_estimate_.push_back(0.0);
+
+    cleanUp();
+
+    if (data_list_.size() > 3)
+    {
+      alignLocalToGlobal(msg->pose_global.header);
+      publishPaths();
+      used_length_ = data_list_.back().cumulative_length - data_list_.front().cumulative_length;
+    }
+  }
+
+  void cleanUp()
+  {
+    if (data_list_.empty())
+    {
+      return;
+    }
+    double length = data_list_.back().cumulative_length - data_list_.front().cumulative_length;
+    while (length > 150.0 && !data_list_.empty())
+    {
+      data_list_.erase(data_list_.begin());
+      time_stamps_.erase(time_stamps_.begin());
+      global_path_.poses.erase(global_path_.poses.begin());
+      global_poses_.erase(global_poses_.begin());
+      local_path_.poses.erase(local_path_.poses.begin());
+      local_poses_.erase(local_poses_.begin());
+      error_trans_avg_.erase(error_trans_avg_.begin());
+      distances_current_estimate_.erase(distances_current_estimate_.begin());
+      if (data_list_.empty())
+      {
+        break;
+      }
+      length = data_list_.back().cumulative_length - data_list_.front().cumulative_length;
+    }
+  }
+
+  void alignLocalToGlobal(const std_msgs::Header& header)
+  {
+    std::vector<double> penalty = error_trans_avg_;
+    std::vector<double> sorted = penalty;
+    if (!sorted.empty())
+    {
+      std::sort(sorted.begin(), sorted.end());
+      double ref_value = sorted[sorted.size() / 4];
+      std::vector<double> weights = arl::gaussianWeight(penalty, ref_value);
+      current_transform_ = arl::snakeAlignment(local_poses_, global_poses_, weights);
+    }
+    else
+    {
+      current_transform_ = Eigen::Isometry3d::Identity();
+    }
+
+    local_path_transformed_.poses.clear();
+    for (size_t i = 0; i < local_poses_.size(); ++i)
+    {
+      Eigen::Isometry3d pose = current_transform_ * local_poses_[i];
+      geometry_msgs::PoseStamped pose_stamped = arl::se3ToPoseStamped(pose, time_stamps_[i], global_frame_, false);
+      geometry_msgs::PoseStamped out = pose_stamped;
+      out.header = header;
+      out.header.frame_id = global_frame_;
+      local_path_transformed_.poses.push_back(out);
+    }
+  }
+
+  void publishPaths()
+  {
+    global_path_.header.frame_id = global_frame_;
+    global_path_.header.stamp = ros::Time::now();
+    global_path_pub_.publish(global_path_);
+
+    local_path_transformed_.header.frame_id = global_frame_;
+    local_path_transformed_.header.stamp = ros::Time::now();
+    local_path_transformed_pub_.publish(local_path_transformed_);
+  }
+
+  // ROS members
+  ros::NodeHandle nh_;
+  ros::NodeHandle nh_private_;
+  ros::Subscriber sub_;
+  ros::Subscriber local_odom_sub_;
+  ros::Publisher global_path_pub_;
+  ros::Publisher local_path_transformed_pub_;
+  ros::Publisher odom_pub_;
+  bool publish_tf_;
+  tf2_ros::TransformBroadcaster tf_broadcaster_;
+  tf2_ros::Buffer tf_buffer_;
+  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
+  ros::Timer timer_;
+
+  // Data storage
+  std::vector<ais_robot_localization::LocalizationMonitorResult> data_list_;
+  std::vector<ros::Time> time_stamps_;
+  std::vector<Eigen::Isometry3d> global_poses_;
+  std::vector<Eigen::Isometry3d> local_poses_;
+  std::vector<double> error_trans_avg_;
+  std::vector<double> distances_current_estimate_;
+  nav_msgs::Path global_path_;
+  nav_msgs::Path local_path_;
+  nav_msgs::Path local_path_transformed_;
+  nav_msgs::Odometry current_odom_state_;
+
+  std::string global_frame_;
+  std::string local_frame_;
+  Eigen::Isometry3d current_transform_;
+  double used_length_;
+
+  std::recursive_mutex mutex_;
+};
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "alignment_filter_node");
+  AlignmentFilterNode node;
+  ros::spin();
+  return 0;
+}
+

--- a/src/se3_algorithms.cpp
+++ b/src/se3_algorithms.cpp
@@ -1,0 +1,146 @@
+#include "ais_robot_localization/se3_algorithms.h"
+
+#include <Eigen/Geometry>
+#include <algorithm>
+#include <cmath>
+
+namespace ais_robot_localization
+{
+
+Eigen::Isometry3d odomToSe3(const geometry_msgs::Pose& pose)
+{
+  Eigen::Isometry3d se3 = Eigen::Isometry3d::Identity();
+  se3.translation() = Eigen::Vector3d(pose.position.x, pose.position.y, pose.position.z);
+  Eigen::Quaterniond q(pose.orientation.w, pose.orientation.x, pose.orientation.y, pose.orientation.z);
+  se3.linear() = q.toRotationMatrix();
+  return se3;
+}
+
+geometry_msgs::PoseStamped se3ToPoseStamped(const Eigen::Isometry3d& se3,
+                                            const ros::Time& stamp,
+                                            const std::string& frame_id,
+                                            bool z_to_zero)
+{
+  geometry_msgs::PoseStamped pose;
+  pose.header.stamp = stamp;
+  pose.header.frame_id = frame_id;
+  pose.pose.position.x = se3.translation().x();
+  pose.pose.position.y = se3.translation().y();
+  pose.pose.position.z = z_to_zero ? 0.0 : se3.translation().z();
+  Eigen::Quaterniond q(se3.rotation());
+  pose.pose.orientation.x = q.x();
+  pose.pose.orientation.y = q.y();
+  pose.pose.orientation.z = q.z();
+  pose.pose.orientation.w = q.w();
+  return pose;
+}
+
+static void makeSnake(std::vector<Eigen::Isometry3d>& traj, double fatness = 3.0)
+{
+  if (traj.size() < 3)
+  {
+    throw std::runtime_error("To short to be a snake :(");
+  }
+
+  Eigen::Vector4d translation_vector(0.0, 0.0, fatness, 1.0);
+  for (size_t i = 0; i < traj.size() - 1; ++i)
+  {
+    Eigen::Matrix4d rotation = Eigen::Matrix4d::Identity();
+    rotation.block<3,3>(0,0) = traj[i].rotation();
+    Eigen::Vector4d point_translation = rotation * translation_vector;
+    if (i % 2 == 0)
+    {
+      point_translation *= -1.0;
+    }
+    traj[i].translation() += point_translation.head<3>();
+  }
+}
+
+static Eigen::Isometry3d kabschAlgorithm(const std::vector<Eigen::Isometry3d>& a,
+                                         const std::vector<Eigen::Isometry3d>& b,
+                                         const std::vector<double>& weights)
+{
+  size_t N = std::min(a.size(), b.size());
+  Eigen::MatrixXd P(3, N), Q(3, N);
+  for (size_t i = 0; i < N; ++i)
+  {
+    P.col(i) = a[i].translation();
+    Q.col(i) = b[i].translation();
+  }
+
+  Eigen::VectorXd w;
+  if (!weights.empty())
+  {
+    w = Eigen::Map<const Eigen::VectorXd>(weights.data(), N);
+  }
+
+  double wsum = weights.empty() ? static_cast<double>(N) : w.sum();
+  Eigen::Vector3d centroidP = weights.empty() ? P.rowwise().mean() : (P * w / wsum);
+  Eigen::Vector3d centroidQ = weights.empty() ? Q.rowwise().mean() : (Q * w / wsum);
+
+  P.colwise() -= centroidP;
+  Q.colwise() -= centroidQ;
+
+  Eigen::Matrix3d H = Eigen::Matrix3d::Zero();
+  if (weights.empty())
+  {
+    H = P * Q.transpose();
+  }
+  else
+  {
+    for (size_t i = 0; i < N; ++i)
+    {
+      H += weights[i] * P.col(i) * Q.col(i).transpose();
+    }
+  }
+
+  Eigen::JacobiSVD<Eigen::Matrix3d> svd(H, Eigen::ComputeFullU | Eigen::ComputeFullV);
+  Eigen::Matrix3d R = svd.matrixV() * svd.matrixU().transpose();
+  if (R.determinant() < 0)
+  {
+    Eigen::Matrix3d V = svd.matrixV();
+    V.col(2) *= -1.0;
+    R = V * svd.matrixU().transpose();
+  }
+
+  Eigen::Vector3d t = centroidQ - R * centroidP;
+  Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+  transform.linear() = R;
+  transform.translation() = t;
+  return transform;
+}
+
+Eigen::Isometry3d snakeAlignment(const std::vector<Eigen::Isometry3d>& trajectory_in,
+                                 const std::vector<Eigen::Isometry3d>& reference_in,
+                                 const std::vector<double>& weights)
+{
+  std::vector<Eigen::Isometry3d> trajectory = trajectory_in;
+  std::vector<Eigen::Isometry3d> reference = reference_in;
+  makeSnake(trajectory);
+  makeSnake(reference);
+  return kabschAlgorithm(trajectory, reference, weights);
+}
+
+std::vector<double> gaussianWeight(const std::vector<double>& errors, double half_life)
+{
+  std::vector<double> weights;
+  weights.reserve(errors.size());
+  double sigma = half_life / std::sqrt(2.0 * std::log(2.0));
+  for (double e : errors)
+  {
+    double w = std::exp(-0.5 * std::pow(e / sigma, 2.0));
+    weights.push_back(w);
+  }
+  return weights;
+}
+
+double euclideanDistance(const geometry_msgs::Pose& a, const geometry_msgs::Pose& b)
+{
+  double dx = b.position.x - a.position.x;
+  double dy = b.position.y - a.position.y;
+  double dz = b.position.z - a.position.z;
+  return std::sqrt(dx * dx + dy * dy + dz * dz);
+}
+
+}  // namespace ais_robot_localization
+


### PR DESCRIPTION
## Summary
- add SE(3) helper library with Kabsch-based alignment and weighting
- implement alignment_filter_node in C++ using se3 algorithms
- update build and launch files to use the C++ alignment filter

## Testing
- `catkin_make` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7d8070e2c832ca899ce87ae339d67