### PR TITLE
Port Alignment Filter to C++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,7 @@ catkin_package(
     ukf
     ukf_localization_nodelet
     localization_monitor
+    se3_algorithms
   CATKIN_DEPENDS
     angles
     cmake_modules
@@ -153,7 +154,8 @@ add_library(navsat_transform src/navsat_transform.cpp)
 add_library(ekf_localization_nodelet src/ekf_localization_nodelet.cpp)
 add_library(ukf_localization_nodelet src/ukf_localization_nodelet.cpp)
 add_library(navsat_transform_nodelet src/navsat_transform_nodelet.cpp)
-add_library(localization_monitor src/localization_monitor.cpp src/se3_algorithms.cpp)
+add_library(se3_algorithms src/se3_algorithms.cpp src/alignment_filter.cpp)
+add_library(localization_monitor src/localization_monitor.cpp)
 
 # Executables
 add_executable(ekf_localization_node src/ekf_localization_node.cpp)
@@ -161,12 +163,14 @@ add_executable(ukf_localization_node src/ukf_localization_node.cpp)
 add_executable(navsat_transform_node src/navsat_transform_node.cpp)
 add_executable(robot_localization_listener_node src/robot_localization_listener_node.cpp)
 add_executable(localization_monitor_node src/localization_monitor_node.cpp)
+add_executable(alignment_filter_node src/alignment_filter_node.cpp)
 
 # Dependencies
 add_dependencies(filter_base ${PROJECT_NAME}_gencpp)
 add_dependencies(navsat_transform ${PROJECT_NAME}_gencpp)
 add_dependencies(robot_localization_listener_node ${PROJECT_NAME}_gencpp)
 add_dependencies(localization_monitor_node ${PROJECT_NAME}_gencpp)
+add_dependencies(alignment_filter_node ${PROJECT_NAME}_gencpp)
 
 # Linking
 target_link_libraries(ros_filter_utilities ${catkin_LIBRARIES} ${EIGEN3_LIBRARIES})
@@ -186,8 +190,10 @@ target_link_libraries(ukf_localization_nodelet ros_filter ${catkin_LIBRARIES})
 target_link_libraries(navsat_transform filter_utilities ros_filter_utilities ${catkin_LIBRARIES} ${EIGEN3_LIBRARIES} ${GeographicLib_LIBRARIES})
 target_link_libraries(navsat_transform_node navsat_transform ${catkin_LIBRARIES} ${GeographicLib_LIBRARIES})
 target_link_libraries(navsat_transform_nodelet navsat_transform ${catkin_LIBRARIES} ${GeographicLib_LIBRARIES})
-target_link_libraries(localization_monitor ${catkin_LIBRARIES} ${EIGEN3_LIBRARIES})
+target_link_libraries(se3_algorithms ${catkin_LIBRARIES} ${EIGEN3_LIBRARIES})
+target_link_libraries(localization_monitor se3_algorithms ${catkin_LIBRARIES} ${EIGEN3_LIBRARIES})
 target_link_libraries(localization_monitor_node localization_monitor ${catkin_LIBRARIES} ${EIGEN3_LIBRARIES})
+target_link_libraries(alignment_filter_node se3_algorithms ${catkin_LIBRARIES} ${EIGEN3_LIBRARIES})
 
 #############
 ## Install ##
@@ -208,6 +214,7 @@ install(TARGETS
   ukf
   ukf_localization_nodelet
   localization_monitor
+  se3_algorithms
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})
@@ -218,6 +225,7 @@ install(TARGETS
   robot_localization_listener_node
   ukf_localization_node
   localization_monitor_node
+  alignment_filter_node
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
 ## Mark cpp header files for installation

--- a/include/ais_robot_localization/alignment_filter.hpp
+++ b/include/ais_robot_localization/alignment_filter.hpp
@@ -1,0 +1,57 @@
+#ifndef AIS_ROBOT_LOCALIZATION_ALIGNMENT_FILTER_HPP
+#define AIS_ROBOT_LOCALIZATION_ALIGNMENT_FILTER_HPP
+
+#include <cstddef>
+#include <vector>
+
+#include <Eigen/Geometry>
+
+namespace ais_robot_localization {
+
+struct AlignmentResult {
+    Eigen::Isometry3d transform{Eigen::Isometry3d::Identity()};
+    std::vector<Eigen::Isometry3d> transformed_local;
+    double used_length{0.0};
+};
+
+class AlignmentFilter {
+  public:
+    AlignmentFilter();
+
+    void setMaxWindowLength(double length);
+
+    std::size_t addMeasurement(const Eigen::Isometry3d& global_pose,
+                               const Eigen::Isometry3d& local_pose,
+                               double timestamp_sec,
+                               double translational_error,
+                               double cumulative_length);
+
+    bool hasSufficientData() const;
+
+    bool computeAlignment(AlignmentResult& result);
+
+    const std::vector<Eigen::Isometry3d>& globalPoses() const { return global_poses_; }
+    const std::vector<Eigen::Isometry3d>& localPoses() const { return local_poses_; }
+    const std::vector<double>& timestamps() const { return timestamps_; }
+    const std::vector<double>& translationalErrors() const { return translational_errors_; }
+    const Eigen::Isometry3d& currentTransform() const { return current_transform_; }
+    double usedLength() const { return used_length_; }
+
+  private:
+    std::size_t cleanup();
+    static double percentile(const std::vector<double>& values, double percent);
+
+    double max_window_length_;
+    std::vector<Eigen::Isometry3d> global_poses_;
+    std::vector<Eigen::Isometry3d> local_poses_;
+    std::vector<double> timestamps_;
+    std::vector<double> translational_errors_;
+    std::vector<double> cumulative_lengths_;
+
+    Eigen::Isometry3d current_transform_;
+    double used_length_;
+};
+
+}  // namespace ais_robot_localization
+
+#endif  // AIS_ROBOT_LOCALIZATION_ALIGNMENT_FILTER_HPP

--- a/include/ais_robot_localization/se3_algorithms.hpp
+++ b/include/ais_robot_localization/se3_algorithms.hpp
@@ -23,6 +23,9 @@ PoseStamped se3ToPoseStamped(const Eigen::Isometry3d& transform,
 double calculateEuclideanDistance(const Eigen::Isometry3d& pose1,
                                   const Eigen::Isometry3d& pose2);
 
+std::vector<double> gaussianWeights(const std::vector<double>& errors,
+                                    double half_life);
+
 void kabschAlgorithm(const std::vector<Eigen::Vector3d>& src,
                      const std::vector<Eigen::Vector3d>& dst,
                      Eigen::Matrix3d& rotation,

--- a/launch/alignment_filter_geo_kombi_no_tf.launch
+++ b/launch/alignment_filter_geo_kombi_no_tf.launch
@@ -2,7 +2,7 @@
     <rosparam command="load" file="$(find ais_robot_localization)/params/alignment_filter_geo_kombi_no_tf.yaml" />
 
 
-    <node name="alignment_filter" pkg="ais_robot_localization" type="alignment_filter_node.py" output="screen">     
+    <node name="alignment_filter" pkg="ais_robot_localization" type="alignment_filter_node" output="screen">
         <remap from="/local_odom" to="/localization/odometry/odom_lidar"/>
         <remap from="/alignment_odometry" to="/localization/alignment_filter/odom_map"/>
         <remap from="/alignment_global_path" to="/localization/alignment_filter/global_path"/>

--- a/launch/alignment_filter_geo_kombi_standard.launch
+++ b/launch/alignment_filter_geo_kombi_standard.launch
@@ -2,7 +2,7 @@
     <rosparam command="load" file="$(find ais_robot_localization)/params/alignment_filter_geo_kombi_standard.yaml" />
 
 
-    <node name="alignment_filter" pkg="ais_robot_localization" type="alignment_filter_node.py" output="screen">     
+    <node name="alignment_filter" pkg="ais_robot_localization" type="alignment_filter_node" output="screen">
         <remap from="/local_odom" to="/localization/odometry/odom_lidar"/>
         <remap from="/alignment_odometry" to="/localization/alignment_filter/odom_map"/>
         <remap from="/alignment_global_path" to="/localization/alignment_filter/global_path"/>

--- a/launch/alignment_filter_sim.launch
+++ b/launch/alignment_filter_sim.launch
@@ -2,7 +2,7 @@
     <rosparam command="load" file="$(find ais_robot_localization)/params/alignment_filter_geo_kombi_standard.yaml" />
 
 
-    <node name="alignment_filter" pkg="ais_robot_localization" type="alignment_filter_node.py" output="screen">     
+    <node name="alignment_filter" pkg="ais_robot_localization" type="alignment_filter_node" output="screen">
         <remap from="/local_odom" to="/localization/odometry/odom_lidar"/>
         <remap from="/alignment_odometry" to="/localization/alignment_filter/odom_map"/>
         <remap from="/alignment_global_path" to="/localization/alignment_filter/global_path"/>

--- a/src/alignment_filter.cpp
+++ b/src/alignment_filter.cpp
@@ -1,0 +1,116 @@
+#include "ais_robot_localization/alignment_filter.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+#include "ais_robot_localization/se3_algorithms.hpp"
+
+namespace ais_robot_localization {
+
+namespace {
+constexpr std::size_t kMinSamples = 4;
+constexpr double kDefaultWindowLength = 150.0;
+}  // namespace
+
+AlignmentFilter::AlignmentFilter()
+    : max_window_length_(kDefaultWindowLength),
+      current_transform_(Eigen::Isometry3d::Identity()),
+      used_length_(0.0) {}
+
+void AlignmentFilter::setMaxWindowLength(double length) {
+    if (length > 0.0) {
+        max_window_length_ = length;
+    }
+}
+
+std::size_t AlignmentFilter::addMeasurement(const Eigen::Isometry3d& global_pose,
+                                            const Eigen::Isometry3d& local_pose,
+                                            double timestamp_sec,
+                                            double translational_error,
+                                            double cumulative_length) {
+    global_poses_.push_back(global_pose);
+    local_poses_.push_back(local_pose);
+    timestamps_.push_back(timestamp_sec);
+    translational_errors_.push_back(translational_error);
+    cumulative_lengths_.push_back(cumulative_length);
+
+    std::size_t removed = cleanup();
+
+    if (cumulative_lengths_.size() >= 2) {
+        used_length_ = cumulative_lengths_.back() - cumulative_lengths_.front();
+    } else {
+        used_length_ = 0.0;
+    }
+
+    return removed;
+}
+
+bool AlignmentFilter::hasSufficientData() const {
+    return global_poses_.size() >= kMinSamples && local_poses_.size() >= kMinSamples;
+}
+
+bool AlignmentFilter::computeAlignment(AlignmentResult& result) {
+    if (!hasSufficientData()) {
+        return false;
+    }
+
+    std::vector<Eigen::Isometry3d> local_for_alignment = local_poses_;
+    std::vector<double> weights = gaussianWeights(translational_errors_, percentile(translational_errors_, 25.0));
+    const std::vector<double>* weights_ptr = nullptr;
+    if (weights.size() == local_for_alignment.size()) {
+        weights_ptr = &weights;
+    }
+
+    Eigen::Isometry3d transform = alignTrajectories(local_for_alignment, global_poses_, weights_ptr);
+
+    current_transform_ = transform;
+    result.transform = transform;
+    result.transformed_local = std::move(local_for_alignment);
+    result.used_length = used_length_;
+
+    return true;
+}
+
+std::size_t AlignmentFilter::cleanup() {
+    if (cumulative_lengths_.empty()) {
+        return 0U;
+    }
+
+    std::size_t removed = 0U;
+    while (cumulative_lengths_.size() > 1 &&
+           cumulative_lengths_.back() - cumulative_lengths_.front() > max_window_length_) {
+        global_poses_.erase(global_poses_.begin());
+        local_poses_.erase(local_poses_.begin());
+        timestamps_.erase(timestamps_.begin());
+        translational_errors_.erase(translational_errors_.begin());
+        cumulative_lengths_.erase(cumulative_lengths_.begin());
+        ++removed;
+    }
+
+    return removed;
+}
+
+double AlignmentFilter::percentile(const std::vector<double>& values, double percent) {
+    if (values.empty()) {
+        return 0.0;
+    }
+
+    std::vector<double> sorted = values;
+    std::sort(sorted.begin(), sorted.end());
+
+    if (sorted.size() == 1U) {
+        return sorted.front();
+    }
+
+    double rank = percent / 100.0 * static_cast<double>(sorted.size() - 1U);
+    double lower_idx = std::floor(rank);
+    double upper_idx = std::ceil(rank);
+    double fraction = rank - lower_idx;
+
+    double lower_value = sorted[static_cast<std::size_t>(lower_idx)];
+    double upper_value = sorted[static_cast<std::size_t>(upper_idx)];
+
+    return lower_value + (upper_value - lower_value) * fraction;
+}
+
+}  // namespace ais_robot_localization

--- a/src/alignment_filter_node.cpp
+++ b/src/alignment_filter_node.cpp
@@ -1,0 +1,266 @@
+#include <algorithm>
+#include <cmath>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include <ros/ros.h>
+#include <geometry_msgs/Pose.h>
+#include <geometry_msgs/PoseStamped.h>
+#include <geometry_msgs/TransformStamped.h>
+#include <nav_msgs/Odometry.h>
+#include <nav_msgs/Path.h>
+#include <tf2_ros/transform_broadcaster.h>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
+#include <tf2/exceptions.h>
+
+#include "ais_robot_localization/LocalizationMonitorResult.h"
+#include "ais_robot_localization/alignment_filter.hpp"
+#include "ais_robot_localization/se3_algorithms.hpp"
+
+namespace ais_robot_localization {
+namespace {
+
+Eigen::Quaterniond toEigenQuaternion(const geometry_msgs::Quaternion& q_msg) {
+  Eigen::Quaterniond q(q_msg.w, q_msg.x, q_msg.y, q_msg.z);
+  if (q.norm() == 0.0) {
+    return Eigen::Quaterniond::Identity();
+  }
+  q.normalize();
+  return q;
+}
+
+Eigen::Isometry3d poseMsgToIsometry(const geometry_msgs::Pose& pose_msg) {
+  Eigen::Vector3d position(pose_msg.position.x, pose_msg.position.y, pose_msg.position.z);
+  Eigen::Quaterniond orientation = toEigenQuaternion(pose_msg.orientation);
+  return odomToSE3(position, orientation);
+}
+
+geometry_msgs::PoseStamped toRosPoseStamped(const PoseStamped& pose, const std::string& frame_id, const ros::Time& stamp) {
+  geometry_msgs::PoseStamped msg;
+  msg.header.frame_id = frame_id;
+  msg.header.stamp = stamp;
+  msg.pose.position.x = pose.position.x();
+  msg.pose.position.y = pose.position.y();
+  msg.pose.position.z = pose.position.z();
+  msg.pose.orientation.x = pose.orientation.x();
+  msg.pose.orientation.y = pose.orientation.y();
+  msg.pose.orientation.z = pose.orientation.z();
+  msg.pose.orientation.w = pose.orientation.w();
+  return msg;
+}
+
+geometry_msgs::Pose toRosPose(const Eigen::Isometry3d& transform) {
+  geometry_msgs::Pose pose_msg;
+  Eigen::Quaterniond q(transform.linear());
+  q.normalize();
+  pose_msg.position.x = transform.translation().x();
+  pose_msg.position.y = transform.translation().y();
+  pose_msg.position.z = transform.translation().z();
+  pose_msg.orientation.x = q.x();
+  pose_msg.orientation.y = q.y();
+  pose_msg.orientation.z = q.z();
+  pose_msg.orientation.w = q.w();
+  return pose_msg;
+}
+
+}  // namespace
+
+class AlignmentFilterNode {
+ public:
+  AlignmentFilterNode()
+      : nh_(),
+        private_nh_("~"),
+        publish_tf_(private_nh_.param("publish_tf", true)),
+        tf_buffer_(),
+        tf_listener_(nullptr),
+        current_transform_(Eigen::Isometry3d::Identity()) {
+    global_frame_ = "map";
+    local_frame_ = "odom";
+
+    global_path_pub_ = nh_.advertise<nav_msgs::Path>("/alignment_global_path", 10);
+    local_path_transformed_pub_ = nh_.advertise<nav_msgs::Path>("/alignment_local_path_transformed", 10);
+    odom_pub_ = nh_.advertise<nav_msgs::Odometry>("/alignment_odometry", 10);
+
+    localization_result_sub_ = nh_.subscribe("/localization_result", 50, &AlignmentFilterNode::localizationMonitorCallback, this);
+    local_odom_sub_ = nh_.subscribe("/local_odom", 50, &AlignmentFilterNode::localOdomCallback, this);
+
+    if (publish_tf_) {
+      tf_buffer_.reset(new tf2_ros::Buffer());
+      tf_listener_.reset(new tf2_ros::TransformListener(*tf_buffer_));
+      tf_timer_ = nh_.createTimer(ros::Duration(0.2), &AlignmentFilterNode::publishTransformTimer, this);
+    }
+
+    ROS_INFO("AlignmentFilterNode initialized (CPP)");
+  }
+
+  void spin() const {
+    ros::spin();
+  }
+
+ private:
+  void localizationMonitorCallback(const ais_robot_localization::LocalizationMonitorResult::ConstPtr& msg) {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    if (!msg->pose_global.header.frame_id.empty()) {
+      global_frame_ = msg->pose_global.header.frame_id;
+    }
+    if (!msg->pose_local.header.frame_id.empty()) {
+      local_frame_ = msg->pose_local.header.frame_id;
+    }
+
+    global_path_.poses.push_back(msg->pose_global);
+    local_path_.poses.push_back(msg->pose_local);
+
+    Eigen::Isometry3d global_pose = poseMsgToIsometry(msg->pose_global.pose);
+    Eigen::Isometry3d local_pose = poseMsgToIsometry(msg->pose_local.pose);
+    double timestamp_sec = msg->pose_global.header.stamp.toSec();
+    double cumulative_length = msg->cumulative_length;
+    double trans_error = msg->float_array.empty() ? 0.0 : static_cast<double>(msg->float_array.front());
+
+    std::size_t removed = filter_.addMeasurement(global_pose, local_pose, timestamp_sec, trans_error, cumulative_length);
+
+    if (removed > 0) {
+      if (global_path_.poses.size() > removed) {
+        global_path_.poses.erase(global_path_.poses.begin(), global_path_.poses.begin() + removed);
+      } else {
+        global_path_.poses.clear();
+      }
+
+      if (local_path_.poses.size() > removed) {
+        local_path_.poses.erase(local_path_.poses.begin(), local_path_.poses.begin() + removed);
+      } else {
+        local_path_.poses.clear();
+      }
+    }
+
+    if (filter_.hasSufficientData()) {
+      AlignmentResult result;
+      if (filter_.computeAlignment(result)) {
+        current_transform_ = result.transform;
+        updateTransformedPath(result.transformed_local, filter_.timestamps(), msg->pose_global.header);
+        publishPaths();
+      }
+    }
+  }
+
+  void localOdomCallback(const nav_msgs::Odometry::ConstPtr& msg) {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    Eigen::Vector3d position(msg->pose.pose.position.x, msg->pose.pose.position.y, msg->pose.pose.position.z);
+    Eigen::Quaterniond orientation = toEigenQuaternion(msg->pose.pose.orientation);
+    Eigen::Isometry3d current_pose = odomToSE3(position, orientation);
+    Eigen::Isometry3d transformed_pose = current_transform_ * current_pose;
+
+    nav_msgs::Odometry transformed_msg;
+    transformed_msg = *msg;
+    transformed_msg.header.frame_id = global_frame_;
+    transformed_msg.pose.pose = toRosPose(transformed_pose);
+    transformed_msg.pose.covariance = {
+        1.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+        0.0, 1.0, 0.0, 0.0, 0.0, 0.0,
+        0.0, 0.0, 1.0, 0.0, 0.0, 0.0,
+        0.0, 0.0, 0.0, 0.1, 0.0, 0.0,
+        0.0, 0.0, 0.0, 0.0, 0.1, 0.0,
+        0.0, 0.0, 0.0, 0.0, 0.0, 0.1};
+
+    odom_pub_.publish(transformed_msg);
+  }
+
+  void updateTransformedPath(const std::vector<Eigen::Isometry3d>& transformed_local,
+                             const std::vector<double>& time_stamps,
+                             const std_msgs::Header& header) {
+    local_path_transformed_.poses.clear();
+    local_path_transformed_.header.frame_id = global_frame_;
+    local_path_transformed_.header.stamp = ros::Time::now();
+
+    for (std::size_t i = 0; i < transformed_local.size(); ++i) {
+      double stamp = (i < time_stamps.size()) ? time_stamps[i] : header.stamp.toSec();
+      PoseStamped pose = se3ToPoseStamped(transformed_local[i], stamp, false);
+      geometry_msgs::PoseStamped ros_pose = toRosPoseStamped(pose, global_frame_, ros::Time(stamp));
+      local_path_transformed_.poses.push_back(ros_pose);
+    }
+  }
+
+  void publishPaths() {
+    ros::Time now = ros::Time::now();
+    global_path_.header.frame_id = global_frame_;
+    global_path_.header.stamp = now;
+    local_path_transformed_.header.stamp = now;
+
+    global_path_pub_.publish(global_path_);
+    local_path_transformed_pub_.publish(local_path_transformed_);
+
+    ROS_INFO("Published global and local transformed paths with %zu poses", global_path_.poses.size());
+  }
+
+  void publishTransformTimer(const ros::TimerEvent&) {
+    if (!publish_tf_ || !tf_buffer_ || !tf_listener_) {
+      return;
+    }
+
+    try {
+      geometry_msgs::TransformStamped latest_tf = tf_buffer_->lookupTransform(local_frame_, "base_link", ros::Time(0), ros::Duration(1.0));
+      geometry_msgs::TransformStamped transform_msg;
+      transform_msg.header.stamp = latest_tf.header.stamp;
+      transform_msg.header.frame_id = global_frame_;
+      transform_msg.child_frame_id = local_frame_;
+
+      Eigen::Quaterniond q(current_transform_.linear());
+      q.normalize();
+      Eigen::Vector3d t = current_transform_.translation();
+
+      transform_msg.transform.translation.x = t.x();
+      transform_msg.transform.translation.y = t.y();
+      transform_msg.transform.translation.z = t.z();
+      transform_msg.transform.rotation.x = q.x();
+      transform_msg.transform.rotation.y = q.y();
+      transform_msg.transform.rotation.z = q.z();
+      transform_msg.transform.rotation.w = q.w();
+
+      tf_broadcaster_.sendTransform(transform_msg);
+    } catch (const tf2::TransformException& ex) {
+      ROS_ERROR_STREAM_THROTTLE(1.0, "Error publishing transform: " << ex.what());
+    }
+  }
+
+  ros::NodeHandle nh_;
+  ros::NodeHandle private_nh_;
+  bool publish_tf_;
+
+  ros::Publisher global_path_pub_;
+  ros::Publisher local_path_transformed_pub_;
+  ros::Publisher odom_pub_;
+
+  ros::Subscriber localization_result_sub_;
+  ros::Subscriber local_odom_sub_;
+
+  std::unique_ptr<tf2_ros::Buffer> tf_buffer_;
+  std::unique_ptr<tf2_ros::TransformListener> tf_listener_;
+  tf2_ros::TransformBroadcaster tf_broadcaster_;
+  ros::Timer tf_timer_;
+
+  nav_msgs::Path global_path_;
+  nav_msgs::Path local_path_;
+  nav_msgs::Path local_path_transformed_;
+
+  std::string global_frame_;
+  std::string local_frame_;
+
+  AlignmentFilter filter_;
+  Eigen::Isometry3d current_transform_;
+
+  std::mutex mutex_;
+};
+
+}  // namespace ais_robot_localization
+
+int main(int argc, char** argv) {
+  ros::init(argc, argv, "alignment_filter_node");
+  ais_robot_localization::AlignmentFilterNode node;
+  node.spin();
+  return 0;
+}
+

--- a/src/se3_algorithms.cpp
+++ b/src/se3_algorithms.cpp
@@ -1,6 +1,7 @@
 #include "ais_robot_localization/se3_algorithms.hpp"
 
 #include <algorithm>
+#include <cmath>
 #include <numeric>
 
 namespace ais_robot_localization {
@@ -30,6 +31,34 @@ PoseStamped se3ToPoseStamped(const Eigen::Isometry3d& transform,
 double calculateEuclideanDistance(const Eigen::Isometry3d& pose1,
                                   const Eigen::Isometry3d& pose2) {
     return (pose2.translation() - pose1.translation()).norm();
+}
+
+std::vector<double> gaussianWeights(const std::vector<double>& errors,
+                                    double half_life) {
+    std::vector<double> weights;
+    weights.reserve(errors.size());
+
+    if (errors.empty()) {
+        return weights;
+    }
+
+    if (half_life <= 0.0) {
+        weights.assign(errors.size(), 1.0);
+        return weights;
+    }
+
+    double sigma = half_life / std::sqrt(2.0 * std::log(2.0));
+    if (!std::isfinite(sigma) || sigma <= 0.0) {
+        weights.assign(errors.size(), 1.0);
+        return weights;
+    }
+
+    for (double error : errors) {
+        double ratio = error / sigma;
+        weights.push_back(std::exp(-0.5 * ratio * ratio));
+    }
+
+    return weights;
 }
 
 void kabschAlgorithm(const std::vector<Eigen::Vector3d>& src,


### PR DESCRIPTION
## Summary
- extract the ROS-independent alignment filter algorithm into a reusable core that manages measurements, weighting, and transforms
- update the C++ alignment filter node to delegate alignment work to the shared core while keeping ROS-specific publishing and subscriptions separate
- register the new core implementation with the existing se3_algorithms library build target

## Testing
- not run (requires ROS workspace)


------
https://chatgpt.com/codex/tasks/task_e_68dd8fc3719c832c85a7bcf828127e79