### PR TITLE
Restore Python TrajectoryTools utilities for ROS 2 humble

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,10 @@ if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_python REQUIRED)
 find_package(angles REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(rclcpp_components REQUIRED)
 find_package(diagnostic_msgs REQUIRED)
 find_package(diagnostic_updater REQUIRED)
 find_package(geographic_msgs REQUIRED)
@@ -97,6 +99,28 @@ add_executable(
   src/robot_localization_listener_node.cpp
 )
 
+add_library(
+  localization_monitor
+  SHARED
+  src/localization_monitor.cpp
+)
+
+add_library(
+  alignment_filter
+  SHARED
+  src/alignment_filter.cpp
+)
+
+add_executable(
+  localization_monitor_node
+  src/localization_monitor_node.cpp
+)
+
+add_executable(
+  alignment_filter_node
+  src/alignment_filter_node.cpp
+)
+
 target_link_libraries(
   ${library_name}
   ${GeographicLib_LIBRARIES}
@@ -162,6 +186,52 @@ ament_target_dependencies(
   robot_localization_listener_node
   rclcpp
 )
+
+ament_target_dependencies(
+  localization_monitor
+  diagnostic_msgs
+  geometry_msgs
+  nav_msgs
+  rclcpp
+  rclcpp_components
+  tf2
+  tf2_geometry_msgs
+  tf2_ros
+)
+
+ament_target_dependencies(
+  alignment_filter
+  geometry_msgs
+  nav_msgs
+  rclcpp
+  rclcpp_components
+  tf2
+  tf2_geometry_msgs
+  tf2_ros
+)
+
+target_link_libraries(
+  localization_monitor_node
+  localization_monitor
+)
+
+target_link_libraries(
+  alignment_filter_node
+  alignment_filter
+)
+
+ament_target_dependencies(
+  localization_monitor_node
+  rclcpp
+)
+
+ament_target_dependencies(
+  alignment_filter_node
+  rclcpp
+)
+
+rclcpp_components_register_node(localization_monitor "robot_localization::LocalizationMonitor")
+rclcpp_components_register_node(alignment_filter "robot_localization::AlignmentFilter")
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
@@ -288,6 +358,21 @@ if(BUILD_TESTING)
     WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
   )
 
+  add_launch_test(
+    test/test_localization_monitor.launch.py
+    TARGET test_localization_monitor
+  )
+
+  add_launch_test(
+    test/test_alignment_filter.launch.py
+    TARGET test_alignment_filter
+  )
+
+  add_launch_test(
+    test/test_trajectory_tool.launch.py
+    TARGET test_trajectory_tool
+  )
+
   ament_cppcheck(LANGUAGE "c++")
   ament_cpplint()
   ament_lint_cmake()
@@ -328,10 +413,12 @@ install(
   ekf_node
   ukf_node
   robot_localization_listener_node
+  localization_monitor_node
+  alignment_filter_node
   RUNTIME DESTINATION lib/${PROJECT_NAME}
 )
 
-install(TARGETS ${library_name}
+install(TARGETS ${library_name} localization_monitor alignment_filter
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -350,7 +437,15 @@ install(DIRECTORY
   USE_SOURCE_PERMISSIONS
 )
 
+ament_python_install_package(TrajectoryTools)
+
+install(PROGRAMS
+  TrajectoryTools/trajectory_tool.py
+  TrajectoryTools/TrajectoryPlayer.py
+  DESTINATION lib/${PROJECT_NAME}
+)
+
 ament_export_include_directories(include)
-ament_export_libraries(${library_name})
+ament_export_libraries(${library_name} localization_monitor alignment_filter)
 ament_export_dependencies(rosidl_default_runtime)
 ament_package()

--- a/README.md
+++ b/README.md
@@ -4,3 +4,47 @@ robot_localization
 robot_localization is a package of nonlinear state estimation nodes. The package was developed by Charles River Analytics, Inc.
 
 Please see documentation here: http://wiki.ros.org/robot_localization
+
+## Additional Nodes
+
+### Localization monitor
+
+The `localization_monitor` node subscribes to a target localization topic and a
+reference topic and checks the positional, angular, and velocity deviations
+between the two. Thresholds are configurable via ROS parameters and the node can
+emit diagnostics to integrate with existing monitoring pipelines.
+
+Launch example: `ros2 launch robot_localization localization_monitor.launch.py`
+
+An integration test covering the diagnostic behavior is available via
+`colcon test --packages-select robot_localization --event-handlers console_direct+`.
+
+### Alignment filter
+
+The `alignment_filter` node compares two odometry streams and computes the
+transform aligning the moving frame with the reference frame. The node can
+publish the resulting transform to TF, republish the aligned odometry in the
+reference frame, and expose the alignment transform as a standalone topic.
+
+Launch example: `ros2 launch robot_localization alignment_filter.launch.py`
+
+The `test_alignment_filter.launch.py` integration test verifies the transform
+and aligned odometry outputs when the filter receives simple synthetic data.
+
+### Trajectory tool
+
+The `trajectory_tool` node aggregates odometry streams into `nav_msgs/Path`
+messages for visualization and comparison. It always publishes a path for the
+target localization topic and can optionally track a reference stream and the
+relative pose between the target and reference states when both are available.
+
+Launch example: `ros2 launch robot_localization trajectory_tool.launch.py`
+
+The `TrajectoryTools/TrajectoryPlayer.py` utility can replay recorded YAML
+trajectory samples as odometry messages for the node to visualize. Provide the
+file path with the `trajectory_file` parameter when starting the player with
+`ros2 run robot_localization TrajectoryPlayer.py` or via a launch file.
+
+The `test_trajectory_tool.launch.py` integration test exercises the path
+outputs and verifies the difference path matches the expected offset between
+the target and reference odometry.

--- a/TrajectoryTools/TrajectoryPlayer.py
+++ b/TrajectoryTools/TrajectoryPlayer.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Replay recorded trajectory samples as odometry messages."""
+
+from __future__ import annotations
+
+import pathlib
+from dataclasses import dataclass
+from typing import List, Optional
+
+import rclpy
+from geometry_msgs.msg import Pose, PoseWithCovariance, Twist, TwistWithCovariance
+from nav_msgs.msg import Odometry
+from rclpy.duration import Duration
+from rclpy.node import Node
+from rclpy.time import Time
+import yaml
+
+
+@dataclass
+class TrajectorySample:
+    """A single trajectory sample loaded from disk."""
+
+    time_from_start: float
+    frame_id: str
+    child_frame_id: str
+    pose: Pose
+    twist: Twist
+
+
+def _load_pose(data: dict) -> Pose:
+    pose = Pose()
+    position = data.get('position', {})
+    pose.position.x = float(position.get('x', 0.0))
+    pose.position.y = float(position.get('y', 0.0))
+    pose.position.z = float(position.get('z', 0.0))
+
+    orientation = data.get('orientation', {})
+    pose.orientation.x = float(orientation.get('x', 0.0))
+    pose.orientation.y = float(orientation.get('y', 0.0))
+    pose.orientation.z = float(orientation.get('z', 0.0))
+    pose.orientation.w = float(orientation.get('w', 1.0))
+    return pose
+
+
+def _load_twist(data: dict) -> Twist:
+    twist = Twist()
+    linear = data.get('linear', {})
+    twist.linear.x = float(linear.get('x', 0.0))
+    twist.linear.y = float(linear.get('y', 0.0))
+    twist.linear.z = float(linear.get('z', 0.0))
+
+    angular = data.get('angular', {})
+    twist.angular.x = float(angular.get('x', 0.0))
+    twist.angular.y = float(angular.get('y', 0.0))
+    twist.angular.z = float(angular.get('z', 0.0))
+    return twist
+
+
+class TrajectoryPlayer(Node):
+    """Publish odometry messages for a recorded trajectory."""
+
+    def __init__(self) -> None:
+        super().__init__('trajectory_player')
+
+        self.trajectory_file = self.declare_parameter('trajectory_file', '').value
+        self.output_topic = self.declare_parameter('output_topic', 'trajectory_player/odometry').value
+        self.publish_rate = float(self.declare_parameter('publish_rate', 30.0).value)
+        self.loop = bool(self.declare_parameter('loop', False).value)
+        self.default_frame_id = self.declare_parameter('frame_id', '').value
+        self.default_child_frame_id = self.declare_parameter('child_frame_id', '').value
+
+        self.samples = self._load_samples(self.trajectory_file)
+        if not self.samples:
+            raise RuntimeError('No trajectory samples available for playback')
+
+        self.publisher = self.create_publisher(Odometry, str(self.output_topic), 10)
+
+        timer_period = 1.0 / self.publish_rate if self.publish_rate > 0.0 else 0.1
+        self.timer = self.create_timer(timer_period, self._on_timer)
+
+        self._start_time: Optional[Time] = None
+        self._index = 0
+
+    def _load_samples(self, file_path: str) -> List[TrajectorySample]:
+        if not file_path:
+            raise RuntimeError('trajectory_file parameter must be provided for TrajectoryPlayer')
+
+        path = pathlib.Path(str(file_path)).expanduser()
+        if not path.exists():
+            raise RuntimeError(f'Trajectory file {path} does not exist')
+
+        with path.open('r', encoding='utf-8') as handle:
+            data = yaml.safe_load(handle) or {}
+
+        if isinstance(data, dict) and 'trajectory' in data:
+            entries = data['trajectory']
+        elif isinstance(data, list):
+            entries = data
+        else:
+            raise RuntimeError('Trajectory file must contain a list of samples or a "trajectory" key')
+
+        samples: List[TrajectorySample] = []
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+
+            time_from_start = float(entry.get('time_from_start', entry.get('stamp', 0.0)))
+            frame_id = str(entry.get('frame_id', self.default_frame_id or 'map'))
+            child_frame_id = str(entry.get('child_frame_id', self.default_child_frame_id or 'base_link'))
+            pose = _load_pose(entry.get('pose', {}))
+            twist = _load_twist(entry.get('twist', {}))
+            samples.append(TrajectorySample(time_from_start, frame_id, child_frame_id, pose, twist))
+
+        samples.sort(key=lambda sample: sample.time_from_start)
+        return samples
+
+    def _on_timer(self) -> None:
+        if self._start_time is None:
+            self._start_time = self.get_clock().now()
+            self._index = 0
+
+        now = self.get_clock().now()
+
+        while self._index < len(self.samples):
+            sample = self.samples[self._index]
+            target_time = self._start_time + Duration(seconds=float(sample.time_from_start))
+            if now < target_time:
+                break
+
+            msg = self._build_odometry(sample, now)
+            self.publisher.publish(msg)
+            self._index += 1
+
+        if self._index >= len(self.samples) and self.loop:
+            self._start_time = now
+            self._index = 0
+
+    def _build_odometry(self, sample: TrajectorySample, stamp: Time) -> Odometry:
+        msg = Odometry()
+        msg.header.stamp = stamp.to_msg()
+        msg.header.frame_id = sample.frame_id
+        msg.child_frame_id = sample.child_frame_id
+
+        msg.pose = PoseWithCovariance()
+        msg.pose.pose = sample.pose
+        msg.twist = TwistWithCovariance()
+        msg.twist.twist = sample.twist
+        return msg
+
+
+def main(args: Optional[list[str]] = None) -> None:
+    rclpy.init(args=args)
+    try:
+        node = TrajectoryPlayer()
+    except RuntimeError as exc:
+        rclpy.logging.get_logger('trajectory_player').error(str(exc))
+        rclpy.shutdown()
+        return
+
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/TrajectoryTools/__init__.py
+++ b/TrajectoryTools/__init__.py
@@ -1,0 +1,4 @@
+"""Python utilities for robot_localization trajectory introspection."""
+
+from .trajectory_tool import main as trajectory_tool_main  # noqa: F401
+from .TrajectoryPlayer import main as trajectory_player_main  # noqa: F401

--- a/TrajectoryTools/trajectory_tool.py
+++ b/TrajectoryTools/trajectory_tool.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""ROS 2 trajectory tool implemented in Python."""
+
+from __future__ import annotations
+
+import collections
+from typing import Deque, Optional
+
+import numpy as np
+import rclpy
+from geometry_msgs.msg import PoseStamped
+from nav_msgs.msg import Odometry, Path
+from rclpy.duration import Duration
+from rclpy.node import Node
+from rclpy.time import Time
+import tf_transformations
+
+
+class TrajectoryToolNode(Node):
+    """Aggregate odometry streams into path messages for visualization."""
+
+    def __init__(self) -> None:
+        super().__init__('trajectory_tool')
+
+        self.target_topic = self.declare_parameter('target_topic', 'odometry/filtered').value
+        self.reference_topic = self.declare_parameter('reference_topic', 'ground_truth').value
+        self.target_path_topic = self.declare_parameter('target_path_topic', 'target_path').value
+        self.reference_path_topic = self.declare_parameter('reference_path_topic', 'reference_path').value
+        self.difference_path_topic = self.declare_parameter('difference_path_topic', 'trajectory_difference').value
+        self.publish_reference_path = bool(self.declare_parameter('publish_reference_path', True).value)
+        self.publish_difference_path = bool(self.declare_parameter('publish_difference_path', True).value)
+        self.max_path_length = int(self.declare_parameter('max_path_length', 0).value)
+        self.sync_tolerance = float(self.declare_parameter('sync_tolerance', 0.05).value)
+        self.reference_buffer_duration = float(
+            self.declare_parameter('reference_buffer_duration', 5.0).value
+        )
+
+        if self.max_path_length < 0:
+            self.get_logger().warn('max_path_length must be non-negative. Resetting to unlimited.')
+            self.max_path_length = 0
+
+        if self.sync_tolerance <= 0.0:
+            self.get_logger().warn('sync_tolerance must be positive. Resetting to 0.05 s.')
+            self.sync_tolerance = 0.05
+
+        if 0.0 < self.reference_buffer_duration < self.sync_tolerance:
+            self.get_logger().warn(
+                'reference_buffer_duration should be greater than sync_tolerance. '
+                'Increasing to match the tolerance.'
+            )
+            self.reference_buffer_duration = self.sync_tolerance
+
+        self.target_path = Path()
+        self.reference_path = Path()
+        self.difference_path = Path()
+
+        self.reference_buffer: Deque[Odometry] = collections.deque()
+
+        self.target_path_pub = self.create_publisher(Path, self.target_path_topic, 10)
+        self.reference_path_pub = None
+        self.difference_path_pub = None
+
+        if self.reference_topic and self.publish_reference_path:
+            self.reference_path_pub = self.create_publisher(Path, self.reference_path_topic, 10)
+
+        if self.reference_topic and self.publish_difference_path:
+            self.difference_path_pub = self.create_publisher(Path, self.difference_path_topic, 10)
+
+        self.target_sub = self.create_subscription(
+            Odometry, self.target_topic, self.target_callback, 10
+        )
+
+        self.reference_sub = None
+        if self.reference_topic:
+            self.reference_sub = self.create_subscription(
+                Odometry, self.reference_topic, self.reference_callback, 10
+            )
+
+    def target_callback(self, msg: Odometry) -> None:
+        pose = PoseStamped()
+        pose.header = msg.header
+        pose.pose = msg.pose.pose
+        self._append_pose(self.target_path, pose)
+        self._prune_path(self.target_path)
+
+        if self.target_path_pub.get_subscription_count() > 0:
+            self.target_path_pub.publish(self.target_path)
+
+        if not self.reference_topic:
+            return
+
+        target_time = Time.from_msg(msg.header.stamp)
+        self._prune_reference_buffer(target_time)
+        reference = self._find_best_reference(target_time)
+        if reference is None:
+            return
+
+        if self.publish_difference_path and self.difference_path_pub:
+            diff_pose = self._compute_difference(msg, reference)
+            if diff_pose is not None:
+                self._append_pose(self.difference_path, diff_pose)
+                self._prune_path(self.difference_path)
+                if self.difference_path_pub.get_subscription_count() > 0:
+                    self.difference_path_pub.publish(self.difference_path)
+
+    def reference_callback(self, msg: Odometry) -> None:
+        pose = PoseStamped()
+        pose.header = msg.header
+        pose.pose = msg.pose.pose
+        self._append_pose(self.reference_path, pose)
+        self._prune_path(self.reference_path)
+
+        if self.reference_path_pub and self.reference_path_pub.get_subscription_count() > 0:
+            self.reference_path_pub.publish(self.reference_path)
+
+        self.reference_buffer.append(msg)
+        self._prune_reference_buffer(Time.from_msg(msg.header.stamp))
+
+    def _compute_difference(self, target: Odometry, reference: Odometry) -> Optional[PoseStamped]:
+        try:
+            target_matrix = self._pose_to_matrix(target.pose.pose)
+            reference_matrix = self._pose_to_matrix(reference.pose.pose)
+        except ValueError as exc:  # pragma: no cover - defensive programming
+            self.get_logger().warn(f'Unable to compute trajectory difference: {exc}')
+            return None
+
+        diff_matrix = tf_transformations.concatenate_matrices(
+            tf_transformations.inverse_matrix(reference_matrix), target_matrix
+        )
+        translation = tf_transformations.translation_from_matrix(diff_matrix)
+        quaternion = tf_transformations.quaternion_from_matrix(diff_matrix)
+
+        pose = PoseStamped()
+        pose.header.stamp = target.header.stamp
+        pose.header.frame_id = reference.header.frame_id
+        pose.pose.position.x = float(translation[0])
+        pose.pose.position.y = float(translation[1])
+        pose.pose.position.z = float(translation[2])
+        pose.pose.orientation.x = float(quaternion[0])
+        pose.pose.orientation.y = float(quaternion[1])
+        pose.pose.orientation.z = float(quaternion[2])
+        pose.pose.orientation.w = float(quaternion[3])
+        return pose
+
+    def _pose_to_matrix(self, pose) -> np.ndarray:
+        quaternion = (
+            pose.orientation.x,
+            pose.orientation.y,
+            pose.orientation.z,
+            pose.orientation.w,
+        )
+        matrix = tf_transformations.quaternion_matrix(quaternion)
+        matrix[0, 3] = pose.position.x
+        matrix[1, 3] = pose.position.y
+        matrix[2, 3] = pose.position.z
+        return matrix
+
+    def _find_best_reference(self, target_time: Time) -> Optional[Odometry]:
+        if not self.reference_buffer:
+            return None
+
+        best_match = None
+        best_delta = self.sync_tolerance
+        for candidate in self.reference_buffer:
+            delta = abs((target_time - Time.from_msg(candidate.header.stamp)).nanoseconds) / 1e9
+            if delta <= best_delta:
+                best_delta = delta
+                best_match = candidate
+        return best_match
+
+    def _prune_reference_buffer(self, stamp: Time) -> None:
+        if self.reference_buffer_duration <= 0.0:
+            return
+
+        minimum_time = stamp - Duration(seconds=self.reference_buffer_duration)
+        while self.reference_buffer:
+            oldest = self.reference_buffer[0]
+            if Time.from_msg(oldest.header.stamp) < minimum_time:
+                self.reference_buffer.popleft()
+            else:
+                break
+
+    def _append_pose(self, path: Path, pose: PoseStamped) -> None:
+        path.header.frame_id = pose.header.frame_id
+        path.header.stamp = pose.header.stamp
+        path.poses.append(pose)
+
+    def _prune_path(self, path: Path) -> None:
+        if self.max_path_length <= 0:
+            return
+
+        overflow = len(path.poses) - self.max_path_length
+        if overflow > 0:
+            del path.poses[:overflow]
+
+
+def main(args: Optional[list[str]] = None) -> None:
+    rclpy.init(args=args)
+    node = TrajectoryToolNode()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/include/robot_localization/alignment_filter.hpp
+++ b/include/robot_localization/alignment_filter.hpp
@@ -1,0 +1,72 @@
+#ifndef ROBOT_LOCALIZATION__ALIGNMENT_FILTER_HPP_
+#define ROBOT_LOCALIZATION__ALIGNMENT_FILTER_HPP_
+
+#include <array>
+#include <memory>
+#include <string>
+
+#include <geometry_msgs/msg/transform_stamped.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <tf2_ros/transform_broadcaster.h>
+
+namespace robot_localization
+{
+
+class AlignmentFilter : public rclcpp::Node
+{
+public:
+  explicit AlignmentFilter(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
+
+  void initialize();
+
+private:
+  void referenceCallback(const nav_msgs::msg::Odometry::SharedPtr msg);
+  void subjectCallback(const nav_msgs::msg::Odometry::SharedPtr msg);
+  void evaluateAlignment();
+  void publishTransform(const geometry_msgs::msg::TransformStamped & transform);
+  void publishAlignedOdometry(const nav_msgs::msg::Odometry & aligned);
+
+  geometry_msgs::msg::TransformStamped computeAlignmentTransform(
+    const nav_msgs::msg::Odometry & reference,
+    const nav_msgs::msg::Odometry & subject) const;
+
+  nav_msgs::msg::Odometry computeAlignedOdometry(
+    const nav_msgs::msg::Odometry & subject,
+    const geometry_msgs::msg::TransformStamped & transform) const;
+
+  void rotateCovariance(
+    const geometry_msgs::msg::Quaternion & rotation,
+    std::array<double, 36> & covariance) const;
+  void rotateTwistCovariance(
+    const geometry_msgs::msg::Quaternion & rotation,
+    std::array<double, 36> & covariance) const;
+
+  rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr reference_sub_;
+  rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr subject_sub_;
+
+  rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr aligned_pub_;
+  rclcpp::Publisher<geometry_msgs::msg::TransformStamped>::SharedPtr transform_pub_;
+
+  std::shared_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
+
+  nav_msgs::msg::Odometry::SharedPtr latest_reference_;
+  nav_msgs::msg::Odometry::SharedPtr latest_subject_;
+
+  std::string reference_topic_;
+  std::string subject_topic_;
+  std::string aligned_topic_;
+  std::string transform_topic_;
+  std::string fixed_frame_id_;
+  std::string moving_frame_id_;
+
+  bool publish_aligned_odometry_;
+  bool publish_tf_;
+  bool publish_transform_topic_;
+
+  double timeout_sec_;
+};
+
+}  // namespace robot_localization
+
+#endif  // ROBOT_LOCALIZATION__ALIGNMENT_FILTER_HPP_

--- a/include/robot_localization/localization_monitor.hpp
+++ b/include/robot_localization/localization_monitor.hpp
@@ -1,0 +1,64 @@
+#ifndef ROBOT_LOCALIZATION__LOCALIZATION_MONITOR_HPP_
+#define ROBOT_LOCALIZATION__LOCALIZATION_MONITOR_HPP_
+
+#include <chrono>
+#include <memory>
+#include <string>
+
+#include <diagnostic_msgs/msg/diagnostic_array.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+namespace robot_localization
+{
+
+class LocalizationMonitor : public rclcpp::Node
+{
+public:
+  explicit LocalizationMonitor(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
+
+private:
+  void targetCallback(const nav_msgs::msg::Odometry::SharedPtr msg);
+  void referenceCallback(const nav_msgs::msg::Odometry::SharedPtr msg);
+  void onTimer();
+
+  double computePositionError(const nav_msgs::msg::Odometry & target,
+    const nav_msgs::msg::Odometry & reference) const;
+  double computeOrientationError(const nav_msgs::msg::Odometry & target,
+    const nav_msgs::msg::Odometry & reference) const;
+  double computeLinearVelocityError(const nav_msgs::msg::Odometry & target,
+    const nav_msgs::msg::Odometry & reference) const;
+  double computeAngularVelocityError(const nav_msgs::msg::Odometry & target,
+    const nav_msgs::msg::Odometry & reference) const;
+
+  void publishDiagnostic(
+    const diagnostic_msgs::msg::DiagnosticStatus & status,
+    const std::string & summary_message);
+
+  nav_msgs::msg::Odometry::SharedPtr target_state_;
+  nav_msgs::msg::Odometry::SharedPtr reference_state_;
+
+  rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr target_sub_;
+  rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr reference_sub_;
+  rclcpp::TimerBase::SharedPtr timer_;
+  rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr diagnostics_pub_;
+
+  std::string target_topic_;
+  std::string reference_topic_;
+  std::string diagnostic_name_;
+  std::string hardware_id_;
+
+  double position_tolerance_;
+  double orientation_tolerance_;
+  double linear_velocity_tolerance_;
+  double angular_velocity_tolerance_;
+  double timeout_sec_;
+  double monitor_frequency_;
+
+  bool publish_diagnostics_;
+
+};
+
+}  // namespace robot_localization
+
+#endif  // ROBOT_LOCALIZATION__LOCALIZATION_MONITOR_HPP_

--- a/launch/alignment_filter.launch.py
+++ b/launch/alignment_filter.launch.py
@@ -1,0 +1,21 @@
+"""Launch alignment filter node with example parameters."""
+
+from launch import LaunchDescription
+from ament_index_python.packages import get_package_share_directory
+from launch_ros.actions import Node
+import os
+
+
+def generate_launch_description() -> LaunchDescription:
+    package_share = get_package_share_directory('robot_localization')
+    parameter_file = os.path.join(package_share, 'params', 'alignment_filter.yaml')
+
+    alignment_node = Node(
+        package='robot_localization',
+        executable='alignment_filter_node',
+        name='alignment_filter',
+        output='screen',
+        parameters=[parameter_file],
+    )
+
+    return LaunchDescription([alignment_node])

--- a/launch/localization_monitor.launch.py
+++ b/launch/localization_monitor.launch.py
@@ -1,0 +1,21 @@
+"""Launch localization monitor node with example parameters."""
+
+from launch import LaunchDescription
+from ament_index_python.packages import get_package_share_directory
+from launch_ros.actions import Node
+import os
+
+
+def generate_launch_description() -> LaunchDescription:
+    package_share = get_package_share_directory('robot_localization')
+    parameter_file = os.path.join(package_share, 'params', 'localization_monitor.yaml')
+
+    monitor_node = Node(
+        package='robot_localization',
+        executable='localization_monitor_node',
+        name='localization_monitor',
+        output='screen',
+        parameters=[parameter_file],
+    )
+
+    return LaunchDescription([monitor_node])

--- a/launch/trajectory_tool.launch.py
+++ b/launch/trajectory_tool.launch.py
@@ -1,0 +1,22 @@
+"""Launch trajectory tool node with example parameters."""
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+
+def generate_launch_description() -> LaunchDescription:
+    package_share = get_package_share_directory('robot_localization')
+    parameter_file = os.path.join(package_share, 'params', 'trajectory_tool.yaml')
+
+    trajectory_node = Node(
+        package='robot_localization',
+        executable='trajectory_tool.py',
+        name='trajectory_tool',
+        output='screen',
+        parameters=[parameter_file],
+    )
+
+    return LaunchDescription([trajectory_node])

--- a/package.xml
+++ b/package.xml
@@ -17,6 +17,7 @@
   <buildtool_depend>builtin_interfaces</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
+  <build_depend>ament_cmake_python</build_depend>
   <build_depend>libboost-dev</build_depend>
   <build_export_depend>libboost-dev</build_export_depend>
 
@@ -31,6 +32,7 @@
   <depend>angles</depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>rmw_implementation</build_depend>
+  <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>
@@ -45,12 +47,19 @@
   <exec_depend>rosidl_default_runtime</exec_depend>
   
   <exec_depend>rclcpp</exec_depend>
+  <exec_depend>rclcpp_components</exec_depend>
+  <exec_depend>rclpy</exec_depend>
   <exec_depend>rmw_implementation</exec_depend>
+  <exec_depend>python3-numpy</exec_depend>
+  <exec_depend>python3-yaml</exec_depend>
+  <exec_depend>tf_transformations</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>launch_ros</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
+  <test_depend>launch_testing</test_depend>
+  <test_depend>rclpy</test_depend>
   
   <member_of_group>rosidl_interface_packages</member_of_group>
 

--- a/params/alignment_filter.yaml
+++ b/params/alignment_filter.yaml
@@ -1,0 +1,12 @@
+alignment_filter:
+  ros__parameters:
+    reference_topic: "map_odometry"
+    subject_topic: "odometry/filtered"
+    aligned_topic: "odometry/aligned"
+    transform_topic: "alignment_transform"
+    fixed_frame_id: "map"
+    moving_frame_id: "odom"
+    publish_tf: true
+    publish_transform_topic: false
+    publish_aligned_odometry: true
+    timeout: 1.0

--- a/params/localization_monitor.yaml
+++ b/params/localization_monitor.yaml
@@ -1,0 +1,11 @@
+localization_monitor:
+  ros__parameters:
+    target_topic: "odometry/filtered"
+    reference_topic: "ground_truth"
+    monitor_frequency: 5.0
+    position_tolerance: 0.5
+    orientation_tolerance: 0.261799
+    linear_velocity_tolerance: 0.5
+    angular_velocity_tolerance: 0.523599
+    timeout: 1.0
+    publish_diagnostics: true

--- a/params/trajectory_tool.yaml
+++ b/params/trajectory_tool.yaml
@@ -1,0 +1,12 @@
+trajectory_tool:
+  ros__parameters:
+    target_topic: "odometry/filtered"
+    reference_topic: "ground_truth"
+    target_path_topic: "target_path"
+    reference_path_topic: "reference_path"
+    difference_path_topic: "trajectory_difference"
+    publish_reference_path: true
+    publish_difference_path: true
+    max_path_length: 0
+    sync_tolerance: 0.1
+    reference_buffer_duration: 5.0

--- a/src/alignment_filter.cpp
+++ b/src/alignment_filter.cpp
@@ -1,0 +1,228 @@
+#include "robot_localization/alignment_filter.hpp"
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cmath>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+#include <Eigen/Dense>
+#include <geometry_msgs/msg/quaternion.hpp>
+#include <tf2/LinearMath/Matrix3x3.h>
+#include <tf2/LinearMath/Quaternion.h>
+#include <tf2/LinearMath/Transform.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+
+namespace robot_localization
+{
+
+namespace
+{
+constexpr double kDefaultTimeout = 1.0;
+}  // namespace
+
+AlignmentFilter::AlignmentFilter(const rclcpp::NodeOptions & options)
+: rclcpp::Node("alignment_filter", options),
+  publish_aligned_odometry_(true),
+  publish_tf_(true),
+  publish_transform_topic_(false),
+  timeout_sec_(kDefaultTimeout)
+{
+  reference_topic_ = this->declare_parameter<std::string>("reference_topic", "map_odometry");
+  subject_topic_ = this->declare_parameter<std::string>("subject_topic", "odom");
+  aligned_topic_ = this->declare_parameter<std::string>("aligned_topic", "odometry/aligned");
+  transform_topic_ = this->declare_parameter<std::string>("transform_topic", "alignment_transform");
+  fixed_frame_id_ = this->declare_parameter<std::string>("fixed_frame_id", "map");
+  moving_frame_id_ = this->declare_parameter<std::string>("moving_frame_id", "odom");
+  publish_aligned_odometry_ = this->declare_parameter<bool>("publish_aligned_odometry", true);
+  publish_tf_ = this->declare_parameter<bool>("publish_tf", true);
+  publish_transform_topic_ = this->declare_parameter<bool>("publish_transform_topic", false);
+  timeout_sec_ = this->declare_parameter<double>("timeout", kDefaultTimeout);
+
+  reference_sub_ = this->create_subscription<nav_msgs::msg::Odometry>(
+    reference_topic_, rclcpp::QoS(rclcpp::KeepLast(10)),
+    std::bind(&AlignmentFilter::referenceCallback, this, std::placeholders::_1));
+
+  subject_sub_ = this->create_subscription<nav_msgs::msg::Odometry>(
+    subject_topic_, rclcpp::QoS(rclcpp::KeepLast(10)),
+    std::bind(&AlignmentFilter::subjectCallback, this, std::placeholders::_1));
+
+  if (publish_aligned_odometry_) {
+    aligned_pub_ = this->create_publisher<nav_msgs::msg::Odometry>(
+      aligned_topic_, rclcpp::QoS(10));
+  }
+
+  if (publish_transform_topic_) {
+    transform_pub_ = this->create_publisher<geometry_msgs::msg::TransformStamped>(
+      transform_topic_, rclcpp::QoS(10));
+  }
+}
+
+void AlignmentFilter::initialize()
+{
+  if (publish_tf_) {
+    tf_broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(shared_from_this());
+  }
+}
+
+void AlignmentFilter::referenceCallback(const nav_msgs::msg::Odometry::SharedPtr msg)
+{
+  latest_reference_ = msg;
+  evaluateAlignment();
+}
+
+void AlignmentFilter::subjectCallback(const nav_msgs::msg::Odometry::SharedPtr msg)
+{
+  latest_subject_ = msg;
+  evaluateAlignment();
+}
+
+void AlignmentFilter::evaluateAlignment()
+{
+  if (!latest_reference_ || !latest_subject_) {
+    return;
+  }
+
+  const rclcpp::Time now = this->now();
+  if (timeout_sec_ > 0.0) {
+    const double reference_age = (now - latest_reference_->header.stamp).seconds();
+    const double subject_age = (now - latest_subject_->header.stamp).seconds();
+    if (reference_age > timeout_sec_) {
+      RCLCPP_WARN_THROTTLE(
+        get_logger(), *this->get_clock(), 2000,
+        "Alignment filter reference data timeout: %.2f seconds", reference_age);
+      return;
+    }
+    if (subject_age > timeout_sec_) {
+      RCLCPP_WARN_THROTTLE(
+        get_logger(), *this->get_clock(), 2000,
+        "Alignment filter subject data timeout: %.2f seconds", subject_age);
+      return;
+    }
+  }
+
+  geometry_msgs::msg::TransformStamped transform = computeAlignmentTransform(
+    *latest_reference_, *latest_subject_);
+
+  publishTransform(transform);
+
+  if (publish_aligned_odometry_) {
+    nav_msgs::msg::Odometry aligned = computeAlignedOdometry(*latest_subject_, transform);
+    publishAlignedOdometry(aligned);
+  }
+}
+
+geometry_msgs::msg::TransformStamped AlignmentFilter::computeAlignmentTransform(
+  const nav_msgs::msg::Odometry & reference,
+  const nav_msgs::msg::Odometry & subject) const
+{
+  tf2::Transform reference_tf;
+  tf2::Transform subject_tf;
+  tf2::fromMsg(reference.pose.pose, reference_tf);
+  tf2::fromMsg(subject.pose.pose, subject_tf);
+
+  tf2::Transform alignment_tf = reference_tf * subject_tf.inverse();
+
+  geometry_msgs::msg::TransformStamped transform;
+  transform.header.stamp = subject.header.stamp;
+  transform.header.frame_id = fixed_frame_id_.empty() ? reference.header.frame_id : fixed_frame_id_;
+  transform.child_frame_id = moving_frame_id_.empty() ? subject.header.frame_id : moving_frame_id_;
+  transform.transform = tf2::toMsg(alignment_tf);
+
+  return transform;
+}
+
+nav_msgs::msg::Odometry AlignmentFilter::computeAlignedOdometry(
+  const nav_msgs::msg::Odometry & subject,
+  const geometry_msgs::msg::TransformStamped & transform) const
+{
+  tf2::Transform subject_tf;
+  tf2::fromMsg(subject.pose.pose, subject_tf);
+
+  tf2::Transform alignment_tf;
+  tf2::fromMsg(transform.transform, alignment_tf);
+
+  tf2::Transform aligned_tf = alignment_tf * subject_tf;
+
+  nav_msgs::msg::Odometry aligned = subject;
+  aligned.header.frame_id = transform.header.frame_id;
+  aligned.pose.pose = tf2::toMsg(aligned_tf);
+  aligned.pose.covariance = subject.pose.covariance;
+  rotateCovariance(transform.transform.rotation, aligned.pose.covariance);
+
+  tf2::Vector3 linear(subject.twist.twist.linear.x, subject.twist.twist.linear.y,
+    subject.twist.twist.linear.z);
+  tf2::Vector3 angular(subject.twist.twist.angular.x, subject.twist.twist.angular.y,
+    subject.twist.twist.angular.z);
+  const tf2::Matrix3x3 basis = alignment_tf.getBasis();
+  linear = basis * linear;
+  angular = basis * angular;
+
+  aligned.twist.twist.linear.x = linear.x();
+  aligned.twist.twist.linear.y = linear.y();
+  aligned.twist.twist.linear.z = linear.z();
+  aligned.twist.twist.angular.x = angular.x();
+  aligned.twist.twist.angular.y = angular.y();
+  aligned.twist.twist.angular.z = angular.z();
+  aligned.twist.covariance = subject.twist.covariance;
+  rotateTwistCovariance(transform.transform.rotation, aligned.twist.covariance);
+
+  return aligned;
+}
+
+void AlignmentFilter::rotateCovariance(
+  const geometry_msgs::msg::Quaternion & rotation,
+  std::array<double, 36> & covariance) const
+{
+  Eigen::Matrix<double, 6, 6> cov =
+    Eigen::Map<const Eigen::Matrix<double, 6, 6, Eigen::RowMajor>>(covariance.data());
+
+  tf2::Quaternion tf_quat;
+  tf2::fromMsg(rotation, tf_quat);
+  tf_quat.normalize();
+
+  Eigen::Quaterniond eigen_quat(tf_quat.w(), tf_quat.x(), tf_quat.y(), tf_quat.z());
+  Eigen::Matrix3d rotation_matrix = eigen_quat.toRotationMatrix();
+
+  Eigen::Matrix<double, 6, 6> rotation_matrix6 = Eigen::Matrix<double, 6, 6>::Identity();
+  rotation_matrix6.block<3, 3>(0, 0) = rotation_matrix;
+  rotation_matrix6.block<3, 3>(3, 3) = rotation_matrix;
+
+  Eigen::Matrix<double, 6, 6> rotated = rotation_matrix6 * cov * rotation_matrix6.transpose();
+
+  Eigen::Map<Eigen::Matrix<double, 6, 6, Eigen::RowMajor>>(covariance.data()) = rotated;
+}
+
+void AlignmentFilter::rotateTwistCovariance(
+  const geometry_msgs::msg::Quaternion & rotation,
+  std::array<double, 36> & covariance) const
+{
+  rotateCovariance(rotation, covariance);
+}
+
+void AlignmentFilter::publishTransform(const geometry_msgs::msg::TransformStamped & transform)
+{
+  if (publish_tf_ && tf_broadcaster_) {
+    tf_broadcaster_->sendTransform(transform);
+  }
+
+  if (publish_transform_topic_ && transform_pub_) {
+    transform_pub_->publish(transform);
+  }
+}
+
+void AlignmentFilter::publishAlignedOdometry(const nav_msgs::msg::Odometry & aligned)
+{
+  if (aligned_pub_) {
+    aligned_pub_->publish(aligned);
+  }
+}
+
+}  // namespace robot_localization
+
+#include "rclcpp_components/register_node_macro.hpp"
+
+RCLCPP_COMPONENTS_REGISTER_NODE(robot_localization::AlignmentFilter)

--- a/src/alignment_filter_node.cpp
+++ b/src/alignment_filter_node.cpp
@@ -1,0 +1,16 @@
+#include <memory>
+
+#include <rclcpp/rclcpp.hpp>
+
+#include "robot_localization/alignment_filter.hpp"
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  rclcpp::NodeOptions options;
+  auto node = std::make_shared<robot_localization::AlignmentFilter>(options);
+  node->initialize();
+  rclcpp::spin(node);
+  rclcpp::shutdown();
+  return 0;
+}

--- a/src/localization_monitor.cpp
+++ b/src/localization_monitor.cpp
@@ -1,0 +1,246 @@
+#include "robot_localization/localization_monitor.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <functional>
+#include <sstream>
+#include <vector>
+
+#include <diagnostic_msgs/msg/diagnostic_status.hpp>
+#include <tf2/LinearMath/Quaternion.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+
+namespace robot_localization
+{
+
+namespace
+{
+constexpr double kDefaultFrequency = 5.0;
+constexpr double kDefaultTolerance = 1.0;
+constexpr double kDefaultAngularTolerance = 0.5;  // radians
+constexpr double kDefaultTimeout = 1.0;
+}  // namespace
+
+LocalizationMonitor::LocalizationMonitor(const rclcpp::NodeOptions & options)
+: rclcpp::Node("localization_monitor", options),
+  position_tolerance_(0.0),
+  orientation_tolerance_(0.0),
+  linear_velocity_tolerance_(0.0),
+  angular_velocity_tolerance_(0.0),
+  timeout_sec_(0.0),
+  monitor_frequency_(0.0),
+  publish_diagnostics_(false)
+{
+  target_topic_ = this->declare_parameter<std::string>("target_topic", "odometry/filtered");
+  reference_topic_ = this->declare_parameter<std::string>("reference_topic", "ground_truth");
+  diagnostic_name_ = this->declare_parameter<std::string>("diagnostic_name", "Localization monitor");
+  hardware_id_ = this->declare_parameter<std::string>("hardware_id", "robot_localization");
+
+  position_tolerance_ = this->declare_parameter<double>("position_tolerance", kDefaultTolerance);
+  orientation_tolerance_ = this->declare_parameter<double>(
+    "orientation_tolerance", kDefaultAngularTolerance);
+  linear_velocity_tolerance_ = this->declare_parameter<double>(
+    "linear_velocity_tolerance", kDefaultTolerance);
+  angular_velocity_tolerance_ = this->declare_parameter<double>(
+    "angular_velocity_tolerance", kDefaultAngularTolerance);
+  timeout_sec_ = this->declare_parameter<double>("timeout", kDefaultTimeout);
+  monitor_frequency_ = this->declare_parameter<double>("monitor_frequency", kDefaultFrequency);
+  publish_diagnostics_ = this->declare_parameter<bool>("publish_diagnostics", true);
+
+  if (monitor_frequency_ <= 0.0) {
+    RCLCPP_WARN(get_logger(), "Monitor frequency must be positive, resetting to %.2f Hz",
+      kDefaultFrequency);
+    monitor_frequency_ = kDefaultFrequency;
+  }
+
+  if (publish_diagnostics_) {
+    diagnostics_pub_ = this->create_publisher<diagnostic_msgs::msg::DiagnosticArray>(
+      "diagnostics", rclcpp::QoS(1));
+  }
+
+  target_sub_ = this->create_subscription<nav_msgs::msg::Odometry>(
+    target_topic_, rclcpp::QoS(rclcpp::KeepLast(10)),
+    std::bind(&LocalizationMonitor::targetCallback, this, std::placeholders::_1));
+
+  reference_sub_ = this->create_subscription<nav_msgs::msg::Odometry>(
+    reference_topic_, rclcpp::QoS(rclcpp::KeepLast(10)),
+    std::bind(&LocalizationMonitor::referenceCallback, this, std::placeholders::_1));
+
+  const auto timer_period = std::chrono::duration<double>(1.0 / monitor_frequency_);
+  timer_ = this->create_wall_timer(timer_period, std::bind(&LocalizationMonitor::onTimer, this));
+}
+
+void LocalizationMonitor::targetCallback(const nav_msgs::msg::Odometry::SharedPtr msg)
+{
+  target_state_ = msg;
+}
+
+void LocalizationMonitor::referenceCallback(const nav_msgs::msg::Odometry::SharedPtr msg)
+{
+  reference_state_ = msg;
+}
+
+void LocalizationMonitor::onTimer()
+{
+  if (!target_state_) {
+    return;
+  }
+
+  diagnostic_msgs::msg::DiagnosticStatus status_msg;
+  status_msg.name = diagnostic_name_;
+  status_msg.hardware_id = hardware_id_;
+  status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+  status_msg.message = "Localization is within tolerance";
+  status_msg.values.reserve(4);
+
+  const auto now = this->now();
+  if (timeout_sec_ > 0.0) {
+    const double target_age = (now - target_state_->header.stamp).seconds();
+    if (target_age > timeout_sec_) {
+      status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+      status_msg.message = "Target localization data timeout";
+      status_msg.values.emplace_back();
+      status_msg.values.back().key = "target_age";
+      status_msg.values.back().value = std::to_string(target_age);
+      publishDiagnostic(status_msg, status_msg.message);
+      RCLCPP_ERROR_THROTTLE(
+        get_logger(), *this->get_clock(), 2000,
+        "Localization monitor did not receive target data for %.2f seconds", target_age);
+      return;
+    }
+
+    if (reference_state_) {
+      const double reference_age = (now - reference_state_->header.stamp).seconds();
+      if (reference_age > timeout_sec_) {
+        status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+        status_msg.message = "Reference localization data timeout";
+        status_msg.values.emplace_back();
+        status_msg.values.back().key = "reference_age";
+        status_msg.values.back().value = std::to_string(reference_age);
+        publishDiagnostic(status_msg, status_msg.message);
+        RCLCPP_WARN_THROTTLE(
+          get_logger(), *this->get_clock(), 2000,
+          "Localization monitor did not receive reference data for %.2f seconds", reference_age);
+        return;
+      }
+    }
+  }
+
+  if (!reference_state_) {
+    status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::STALE;
+    status_msg.message = "Waiting for reference localization";
+    publishDiagnostic(status_msg, status_msg.message);
+    return;
+  }
+
+  const double position_error = computePositionError(*target_state_, *reference_state_);
+  const double orientation_error = computeOrientationError(*target_state_, *reference_state_);
+  const double linear_error = computeLinearVelocityError(*target_state_, *reference_state_);
+  const double angular_error = computeAngularVelocityError(*target_state_, *reference_state_);
+
+  status_msg.values.emplace_back();
+  status_msg.values.back().key = "position_error";
+  status_msg.values.back().value = std::to_string(position_error);
+
+  status_msg.values.emplace_back();
+  status_msg.values.back().key = "orientation_error";
+  status_msg.values.back().value = std::to_string(orientation_error);
+
+  status_msg.values.emplace_back();
+  status_msg.values.back().key = "linear_velocity_error";
+  status_msg.values.back().value = std::to_string(linear_error);
+
+  status_msg.values.emplace_back();
+  status_msg.values.back().key = "angular_velocity_error";
+  status_msg.values.back().value = std::to_string(angular_error);
+
+  auto check_threshold = [&](double value, double limit, const std::string & field) {
+      if (limit >= 0.0 && value > limit) {
+        status_msg.level = std::max(
+          status_msg.level,
+          diagnostic_msgs::msg::DiagnosticStatus::WARN);
+        std::ostringstream stream;
+        stream << field << " exceeds tolerance: " << value << " > " << limit;
+        status_msg.message = stream.str();
+      }
+    };
+
+  check_threshold(position_error, position_tolerance_, "Position error");
+  check_threshold(orientation_error, orientation_tolerance_, "Orientation error");
+  check_threshold(linear_error, linear_velocity_tolerance_, "Linear velocity error");
+  check_threshold(angular_error, angular_velocity_tolerance_, "Angular velocity error");
+
+  if (status_msg.level == diagnostic_msgs::msg::DiagnosticStatus::WARN) {
+    RCLCPP_WARN_THROTTLE(
+      get_logger(), *this->get_clock(), 2000,
+      "Localization monitor detected deviation: position %.3f (tol %.3f), orientation %.3f (tol %.3f)",
+      position_error, position_tolerance_, orientation_error, orientation_tolerance_);
+  }
+
+  publishDiagnostic(status_msg, status_msg.message);
+}
+
+double LocalizationMonitor::computePositionError(
+  const nav_msgs::msg::Odometry & target,
+  const nav_msgs::msg::Odometry & reference) const
+{
+  const double dx = target.pose.pose.position.x - reference.pose.pose.position.x;
+  const double dy = target.pose.pose.position.y - reference.pose.pose.position.y;
+  const double dz = target.pose.pose.position.z - reference.pose.pose.position.z;
+  return std::sqrt(dx * dx + dy * dy + dz * dz);
+}
+
+double LocalizationMonitor::computeOrientationError(
+  const nav_msgs::msg::Odometry & target,
+  const nav_msgs::msg::Odometry & reference) const
+{
+  tf2::Quaternion target_q;
+  tf2::Quaternion reference_q;
+  tf2::fromMsg(target.pose.pose.orientation, target_q);
+  tf2::fromMsg(reference.pose.pose.orientation, reference_q);
+
+  return reference_q.angularDistance(target_q);
+}
+
+double LocalizationMonitor::computeLinearVelocityError(
+  const nav_msgs::msg::Odometry & target,
+  const nav_msgs::msg::Odometry & reference) const
+{
+  const double dx = target.twist.twist.linear.x - reference.twist.twist.linear.x;
+  const double dy = target.twist.twist.linear.y - reference.twist.twist.linear.y;
+  const double dz = target.twist.twist.linear.z - reference.twist.twist.linear.z;
+  return std::sqrt(dx * dx + dy * dy + dz * dz);
+}
+
+double LocalizationMonitor::computeAngularVelocityError(
+  const nav_msgs::msg::Odometry & target,
+  const nav_msgs::msg::Odometry & reference) const
+{
+  const double dx = target.twist.twist.angular.x - reference.twist.twist.angular.x;
+  const double dy = target.twist.twist.angular.y - reference.twist.twist.angular.y;
+  const double dz = target.twist.twist.angular.z - reference.twist.twist.angular.z;
+  return std::sqrt(dx * dx + dy * dy + dz * dz);
+}
+
+void LocalizationMonitor::publishDiagnostic(
+  const diagnostic_msgs::msg::DiagnosticStatus & status,
+  const std::string & summary_message)
+{
+  if (!publish_diagnostics_ || diagnostics_pub_ == nullptr) {
+    return;
+  }
+
+  diagnostic_msgs::msg::DiagnosticArray array_msg;
+  array_msg.header.stamp = this->now();
+  array_msg.status.push_back(status);
+  if (array_msg.status.front().message.empty()) {
+    array_msg.status.front().message = summary_message;
+  }
+  diagnostics_pub_->publish(array_msg);
+}
+
+}  // namespace robot_localization
+
+#include "rclcpp_components/register_node_macro.hpp"
+
+RCLCPP_COMPONENTS_REGISTER_NODE(robot_localization::LocalizationMonitor)

--- a/src/localization_monitor_node.cpp
+++ b/src/localization_monitor_node.cpp
@@ -1,0 +1,15 @@
+#include <memory>
+
+#include <rclcpp/rclcpp.hpp>
+
+#include "robot_localization/localization_monitor.hpp"
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  rclcpp::NodeOptions options;
+  auto node = std::make_shared<robot_localization::LocalizationMonitor>(options);
+  rclcpp::spin(node);
+  rclcpp::shutdown();
+  return 0;
+}

--- a/test/test_alignment_filter.launch.py
+++ b/test/test_alignment_filter.launch.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Integration test for the alignment filter node."""
+
+import math
+import time
+import unittest
+from collections import deque
+
+import launch
+import launch_testing
+import launch_testing.actions
+import launch_testing.tools
+from launch_ros.actions import Node
+
+import rclpy
+from geometry_msgs.msg import TransformStamped
+from nav_msgs.msg import Odometry
+
+
+def generate_test_description():
+    alignment = Node(
+        package='robot_localization',
+        executable='alignment_filter_node',
+        name='alignment_filter',
+        parameters=[{
+            'reference_topic': 'reference_odometry',
+            'subject_topic': 'subject_odometry',
+            'aligned_topic': 'aligned_odometry',
+            'transform_topic': 'alignment_transform',
+            'fixed_frame_id': 'map',
+            'moving_frame_id': 'odom',
+            'publish_tf': False,
+            'publish_transform_topic': True,
+            'publish_aligned_odometry': True,
+            'timeout': 0.0,
+        }],
+        output='screen',
+    )
+
+    return launch.LaunchDescription([
+        alignment,
+        launch_testing.actions.ReadyToTest(),
+    ]), {'alignment_action': alignment}
+
+
+class TestAlignmentFilter(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
+
+    def setUp(self):
+        self.node = rclpy.create_node('alignment_filter_tester')
+        self.transforms = deque()
+        self.aligned_messages = deque()
+        self.transform_sub = self.node.create_subscription(
+            TransformStamped,
+            'alignment_transform',
+            self._transform_callback,
+            10,
+        )
+        self.aligned_sub = self.node.create_subscription(
+            Odometry,
+            'aligned_odometry',
+            self._aligned_callback,
+            10,
+        )
+        self.reference_pub = self.node.create_publisher(Odometry, 'reference_odometry', 10)
+        self.subject_pub = self.node.create_publisher(Odometry, 'subject_odometry', 10)
+        self._wait_for_connections()
+
+    def tearDown(self):
+        self.node.destroy_subscription(self.transform_sub)
+        self.node.destroy_subscription(self.aligned_sub)
+        self.node.destroy_publisher(self.reference_pub)
+        self.node.destroy_publisher(self.subject_pub)
+        self.node.destroy_node()
+
+    def _wait_for_connections(self, timeout=5.0):
+        end_time = time.time() + timeout
+        while time.time() < end_time:
+            publishers_ready = self.reference_pub.get_subscription_count() > 0 and \
+                self.subject_pub.get_subscription_count() > 0
+            subscribers_ready = self.transform_sub.get_publisher_count() > 0 and \
+                self.aligned_sub.get_publisher_count() > 0
+            if publishers_ready and subscribers_ready:
+                return
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+        self.fail('Timed out waiting for alignment filter connections')
+
+    def _transform_callback(self, msg: TransformStamped) -> None:
+        self.transforms.append(msg)
+
+    def _aligned_callback(self, msg: Odometry) -> None:
+        self.aligned_messages.append(msg)
+
+    def _create_odometry(self, x=0.0, y=0.0, yaw=0.0) -> Odometry:
+        odom = Odometry()
+        odom.header.stamp = self.node.get_clock().now().to_msg()
+        odom.pose.pose.position.x = float(x)
+        odom.pose.pose.position.y = float(y)
+        if yaw != 0.0:
+            half_yaw = yaw * 0.5
+            odom.pose.pose.orientation.z = math.sin(half_yaw)
+            odom.pose.pose.orientation.w = math.cos(half_yaw)
+        else:
+            odom.pose.pose.orientation.w = 1.0
+        return odom
+
+    def _publish_pair(self, subject: Odometry, reference: Odometry) -> None:
+        timestamp = self.node.get_clock().now().to_msg()
+        subject.header.stamp = timestamp
+        reference.header.stamp = timestamp
+        self.subject_pub.publish(subject)
+        self.reference_pub.publish(reference)
+
+    def _wait_for_transform(self, timeout=5.0):
+        end_time = time.time() + timeout
+        while time.time() < end_time:
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+            if self.transforms:
+                return self.transforms.popleft()
+        self.fail('Did not receive alignment transform')
+
+    def _wait_for_aligned(self, timeout=5.0):
+        end_time = time.time() + timeout
+        while time.time() < end_time:
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+            if self.aligned_messages:
+                return self.aligned_messages.popleft()
+        self.fail('Did not receive aligned odometry')
+
+    def test_alignment_filter_computes_transform(self):
+        """Alignment filter should publish the transform and aligned odometry."""
+        subject = self._create_odometry(x=1.0, y=0.0)
+        subject.header.frame_id = 'odom'
+        subject.child_frame_id = 'base_link'
+        reference = self._create_odometry(x=4.0, y=0.0)
+        reference.header.frame_id = 'map'
+        reference.child_frame_id = 'base_link_map'
+
+        self._publish_pair(subject, reference)
+        transform = self._wait_for_transform()
+        self.assertEqual(transform.header.frame_id, 'map')
+        self.assertEqual(transform.child_frame_id, 'odom')
+        self.assertAlmostEqual(transform.transform.translation.x, 3.0, places=6)
+        self.assertAlmostEqual(transform.transform.translation.y, 0.0, places=6)
+        self.assertAlmostEqual(transform.transform.translation.z, 0.0, places=6)
+        self.assertAlmostEqual(transform.transform.rotation.w, 1.0, places=6)
+
+        aligned = self._wait_for_aligned()
+        self.assertEqual(aligned.header.frame_id, 'map')
+        self.assertAlmostEqual(aligned.pose.pose.position.x, reference.pose.pose.position.x, places=6)
+        self.assertAlmostEqual(aligned.pose.pose.position.y, reference.pose.pose.position.y, places=6)
+        self.assertAlmostEqual(aligned.pose.pose.position.z, reference.pose.pose.position.z, places=6)
+
+
+@launch_testing.post_shutdown_test()
+class TestAlignmentFilterShutdown(unittest.TestCase):
+
+    def test_exit_code(self, proc_info):
+        proc_info.assertWaitForShutdown(process_matcher=launch_testing.tools.proc_any())

--- a/test/test_localization_monitor.launch.py
+++ b/test/test_localization_monitor.launch.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Integration test for the localization monitor node."""
+
+import math
+import time
+import unittest
+from collections import deque
+
+import launch
+import launch_testing
+import launch_testing.actions
+import launch_testing.tools
+from launch_ros.actions import Node
+
+import rclpy
+from diagnostic_msgs.msg import DiagnosticArray, DiagnosticStatus
+from geometry_msgs.msg import Quaternion
+from nav_msgs.msg import Odometry
+
+
+def generate_test_description():
+    monitor = Node(
+        package='robot_localization',
+        executable='localization_monitor_node',
+        name='localization_monitor',
+        parameters=[{
+            'target_topic': 'test_target',
+            'reference_topic': 'test_reference',
+            'monitor_frequency': 20.0,
+            'position_tolerance': 0.2,
+            'orientation_tolerance': 0.2,
+            'linear_velocity_tolerance': 0.5,
+            'angular_velocity_tolerance': 0.5,
+            'timeout': 0.0,
+            'publish_diagnostics': True,
+        }],
+        output='screen',
+    )
+
+    return launch.LaunchDescription([
+        monitor,
+        launch_testing.actions.ReadyToTest(),
+    ]), {'monitor_action': monitor}
+
+
+class TestLocalizationMonitor(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
+
+    def setUp(self):
+        self.node = rclpy.create_node('localization_monitor_tester')
+        self.diagnostics = deque()
+        self.diag_sub = self.node.create_subscription(
+            DiagnosticArray,
+            'diagnostics',
+            self._diagnostic_callback,
+            10,
+        )
+        self.target_pub = self.node.create_publisher(Odometry, 'test_target', 10)
+        self.reference_pub = self.node.create_publisher(Odometry, 'test_reference', 10)
+        self._wait_for_subscribers()
+
+    def tearDown(self):
+        self.node.destroy_subscription(self.diag_sub)
+        self.node.destroy_publisher(self.target_pub)
+        self.node.destroy_publisher(self.reference_pub)
+        self.node.destroy_node()
+
+    def _wait_for_subscribers(self, timeout=5.0):
+        end_time = time.time() + timeout
+        while time.time() < end_time:
+            if (self.target_pub.get_subscription_count() > 0 and
+                    self.reference_pub.get_subscription_count() > 0):
+                return
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+        self.fail('Timed out waiting for localization monitor subscriptions')
+
+    def _diagnostic_callback(self, msg: DiagnosticArray) -> None:
+        if msg.status:
+            self.diagnostics.append(msg.status[0])
+
+    def _create_odometry(self, x=0.0, y=0.0, yaw=0.0) -> Odometry:
+        odom = Odometry()
+        odom.header.stamp = self.node.get_clock().now().to_msg()
+        odom.pose.pose.position.x = float(x)
+        odom.pose.pose.position.y = float(y)
+        odom.pose.pose.orientation = Quaternion(w=1.0)
+        if yaw != 0.0:
+            half_yaw = yaw * 0.5
+            odom.pose.pose.orientation.z = math.sin(half_yaw)
+            odom.pose.pose.orientation.w = math.cos(half_yaw)
+        return odom
+
+    def _publish_pair(self, target: Odometry, reference: Odometry) -> None:
+        now = self.node.get_clock().now().to_msg()
+        target.header.stamp = now
+        reference.header.stamp = now
+        self.target_pub.publish(target)
+        self.reference_pub.publish(reference)
+
+    def _wait_for_status(self, predicate, timeout=5.0):
+        end_time = time.time() + timeout
+        while time.time() < end_time:
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+            while self.diagnostics:
+                status = self.diagnostics.popleft()
+                if predicate(status):
+                    return status
+        self.fail('Did not receive expected diagnostic status')
+
+    def test_localization_monitor_reports_warnings(self):
+        """Monitor should report OK for matching states and WARN for divergent ones."""
+        ok_target = self._create_odometry(x=1.0, y=2.0)
+        ok_reference = self._create_odometry(x=1.0, y=2.0)
+        self._publish_pair(ok_target, ok_reference)
+        status = self._wait_for_status(lambda s: any(v.key == 'position_error' for v in s.values))
+        self.assertEqual(status.level, DiagnosticStatus.OK)
+        self.assertEqual(status.message, 'Localization is within tolerance')
+
+        self.diagnostics.clear()
+        warn_target = self._create_odometry(x=3.0, y=0.0)
+        warn_reference = self._create_odometry(x=0.0, y=0.0)
+        self._publish_pair(warn_target, warn_reference)
+
+        def warn_predicate(status_msg):
+            for value in status_msg.values:
+                if value.key == 'position_error' and float(value.value) > 2.5:
+                    return True
+            return False
+
+        warn_status = self._wait_for_status(warn_predicate)
+        self.assertEqual(warn_status.level, DiagnosticStatus.WARN)
+        self.assertIn('Position error exceeds tolerance', warn_status.message)
+
+
+@launch_testing.post_shutdown_test()
+class TestLocalizationMonitorShutdown(unittest.TestCase):
+
+    def test_exit_code(self, proc_info):
+        proc_info.assertWaitForShutdown(process_matcher=launch_testing.tools.proc_any())

--- a/test/test_trajectory_tool.launch.py
+++ b/test/test_trajectory_tool.launch.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Integration test for the trajectory tool node."""
+
+import math
+import time
+import unittest
+from collections import deque
+
+import launch
+import launch_testing
+import launch_testing.actions
+from launch_ros.actions import Node
+
+import rclpy
+from nav_msgs.msg import Odometry, Path
+
+
+def generate_test_description():
+    trajectory_node = Node(
+        package='robot_localization',
+        executable='trajectory_tool.py',
+        name='trajectory_tool',
+        parameters=[{
+            'target_topic': 'target_odometry',
+            'reference_topic': 'reference_odometry',
+            'target_path_topic': 'target_path',
+            'reference_path_topic': 'reference_path',
+            'difference_path_topic': 'difference_path',
+            'sync_tolerance': 0.25,
+            'reference_buffer_duration': 2.0,
+            'max_path_length': 10,
+        }],
+        output='screen',
+    )
+
+    return launch.LaunchDescription([
+        trajectory_node,
+        launch_testing.actions.ReadyToTest(),
+    ]), {'trajectory_node': trajectory_node}
+
+
+class TestTrajectoryTool(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
+
+    def setUp(self):
+        self.node = rclpy.create_node('trajectory_tool_tester')
+        self.target_pub = self.node.create_publisher(Odometry, 'target_odometry', 10)
+        self.reference_pub = self.node.create_publisher(Odometry, 'reference_odometry', 10)
+        self.target_paths = deque()
+        self.reference_paths = deque()
+        self.difference_paths = deque()
+        self.target_sub = self.node.create_subscription(Path, 'target_path', self._target_callback, 10)
+        self.reference_sub = self.node.create_subscription(Path, 'reference_path', self._reference_callback, 10)
+        self.difference_sub = self.node.create_subscription(Path, 'difference_path', self._difference_callback, 10)
+        self._wait_for_connections()
+
+    def tearDown(self):
+        self.node.destroy_subscription(self.target_sub)
+        self.node.destroy_subscription(self.reference_sub)
+        self.node.destroy_subscription(self.difference_sub)
+        self.node.destroy_publisher(self.target_pub)
+        self.node.destroy_publisher(self.reference_pub)
+        self.node.destroy_node()
+
+    def _target_callback(self, msg: Path) -> None:
+        self.target_paths.append(msg)
+
+    def _reference_callback(self, msg: Path) -> None:
+        self.reference_paths.append(msg)
+
+    def _difference_callback(self, msg: Path) -> None:
+        self.difference_paths.append(msg)
+
+    def _wait_for_connections(self, timeout=5.0):
+        end_time = time.time() + timeout
+        while time.time() < end_time:
+            pubs_ready = self.target_pub.get_subscription_count() > 0 and \
+                self.reference_pub.get_subscription_count() > 0
+            subs_ready = self.target_sub.get_publisher_count() > 0 and \
+                self.reference_sub.get_publisher_count() > 0 and \
+                self.difference_sub.get_publisher_count() > 0
+            if pubs_ready and subs_ready:
+                return
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+        self.fail('Timed out waiting for trajectory tool connections')
+
+    def _create_odometry(self, x=0.0, y=0.0, yaw=0.0) -> Odometry:
+        odom = Odometry()
+        odom.header.stamp = self.node.get_clock().now().to_msg()
+        odom.pose.pose.position.x = float(x)
+        odom.pose.pose.position.y = float(y)
+        if yaw != 0.0:
+            half_yaw = yaw * 0.5
+            odom.pose.pose.orientation.z = math.sin(half_yaw)
+            odom.pose.pose.orientation.w = math.cos(half_yaw)
+        else:
+            odom.pose.pose.orientation.w = 1.0
+        return odom
+
+    def _publish_pair(self, target: Odometry, reference: Odometry) -> None:
+        timestamp = self.node.get_clock().now().to_msg()
+        target.header.stamp = timestamp
+        reference.header.stamp = timestamp
+        self.target_pub.publish(target)
+        self.reference_pub.publish(reference)
+
+    def _wait_for_path(self, queue: deque, timeout=5.0) -> Path:
+        end_time = time.time() + timeout
+        while time.time() < end_time:
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+            if queue:
+                return queue.pop()
+        self.fail('Did not receive expected path message')
+
+    def test_trajectory_tool_publishes_paths(self):
+        """Trajectory tool should publish target, reference, and difference paths."""
+        target = self._create_odometry(x=2.0, y=-1.0)
+        target.header.frame_id = 'odom'
+        target.child_frame_id = 'base_link'
+
+        reference = self._create_odometry(x=1.0, y=-2.0)
+        reference.header.frame_id = 'map'
+        reference.child_frame_id = 'reference_base'
+
+        self._publish_pair(target, reference)
+
+        target_path = self._wait_for_path(self.target_paths)
+        reference_path = self._wait_for_path(self.reference_paths)
+        difference_path = self._wait_for_path(self.difference_paths)
+
+        self.assertEqual(len(target_path.poses), 1)
+        self.assertEqual(target_path.header.frame_id, 'odom')
+        self.assertAlmostEqual(target_path.poses[0].pose.position.x, 2.0, places=6)
+        self.assertAlmostEqual(target_path.poses[0].pose.position.y, -1.0, places=6)
+
+        self.assertEqual(len(reference_path.poses), 1)
+        self.assertEqual(reference_path.header.frame_id, 'map')
+        self.assertAlmostEqual(reference_path.poses[0].pose.position.x, 1.0, places=6)
+        self.assertAlmostEqual(reference_path.poses[0].pose.position.y, -2.0, places=6)
+
+        self.assertEqual(len(difference_path.poses), 1)
+        self.assertEqual(difference_path.header.frame_id, 'map')
+        diff_pose = difference_path.poses[0].pose
+        self.assertAlmostEqual(diff_pose.position.x, 1.0, places=6)
+        self.assertAlmostEqual(diff_pose.position.y, 1.0, places=6)
+        self.assertAlmostEqual(diff_pose.orientation.w, 1.0, places=6)
+        self.assertAlmostEqual(diff_pose.orientation.z, 0.0, places=6)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- replace the C++ trajectory component with a Python-based node equivalent to the ROS 1 TrajectoryTools behavior
- add a TrajectoryPlayer utility for replaying YAML trajectories and install the TrajectoryTools python package
- update the build system, launch files, documentation, and tests to target the Python scripts

## Testing
- python3 -m compileall TrajectoryTools test/test_trajectory_tool.launch.py

------
https://chatgpt.com/codex/tasks/task_e_68de0ff71978832c8732696c1452c9bb