### PR TITLE
Add RViz alignment filter configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ find_package(GeographicLib REQUIRED)
 set(library_name rl_lib)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
+  "msg/LocalizationMonitorResult.msg"
   "srv/FromLL.srv"
   "srv/GetState.srv"
   "srv/SetDatum.srv"
@@ -68,8 +69,11 @@ add_library(
   src/ukf.cpp
   src/filter_base.cpp
   src/filter_utilities.cpp
+  src/alignment_filter.cpp
+  src/localization_monitor.cpp
   src/navsat_transform.cpp
   src/robot_localization_estimator.cpp
+  src/se3_algorithms.cpp
   src/ros_filter.cpp
   src/ros_filter_utilities.cpp
   src/ros_robot_localization_listener.cpp)
@@ -95,6 +99,16 @@ add_executable(
 add_executable(
   robot_localization_listener_node
   src/robot_localization_listener_node.cpp
+)
+
+add_executable(
+  localization_monitor_node
+  src/localization_monitor_node.cpp
+)
+
+add_executable(
+  alignment_filter_node
+  src/alignment_filter_node.cpp
 )
 
 target_link_libraries(
@@ -162,6 +176,42 @@ ament_target_dependencies(
   robot_localization_listener_node
   rclcpp
 )
+
+target_link_libraries(
+  localization_monitor_node
+  ${library_name}
+)
+
+ament_target_dependencies(
+  localization_monitor_node
+  geometry_msgs
+  nav_msgs
+  rclcpp
+  std_msgs
+  tf2
+  tf2_ros
+)
+
+target_link_libraries(
+  alignment_filter_node
+  ${library_name}
+)
+
+ament_target_dependencies(
+  alignment_filter_node
+  geometry_msgs
+  nav_msgs
+  rclcpp
+  std_msgs
+  tf2
+  tf2_ros
+)
+
+rosidl_target_interfaces(localization_monitor_node
+  ${PROJECT_NAME} "rosidl_typesupport_cpp")
+
+rosidl_target_interfaces(alignment_filter_node
+  ${PROJECT_NAME} "rosidl_typesupport_cpp")
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
@@ -328,6 +378,8 @@ install(
   ekf_node
   ukf_node
   robot_localization_listener_node
+  localization_monitor_node
+  alignment_filter_node
   RUNTIME DESTINATION lib/${PROJECT_NAME}
 )
 
@@ -346,8 +398,15 @@ install(DIRECTORY
 install(DIRECTORY
   params
   launch
+  config
   DESTINATION share/${PROJECT_NAME}
   USE_SOURCE_PERMISSIONS
+)
+
+install(PROGRAMS
+  scripts/navsat_preprocessing_node.py
+  scripts/localization_monitor_pipeline.sh
+  DESTINATION lib/${PROJECT_NAME}
 )
 
 ament_export_include_directories(include)

--- a/README.md
+++ b/README.md
@@ -4,3 +4,35 @@ robot_localization
 robot_localization is a package of nonlinear state estimation nodes. The package was developed by Charles River Analytics, Inc.
 
 Please see documentation here: http://wiki.ros.org/robot_localization
+
+## AIS extensions for ROS 2
+
+This fork adds ROS 2 ports of AIS-specific tools that were previously only available on the
+`noetic-devel` branch:
+
+* **Localization monitor**: evaluates relative pose error (RPE) between a local odometry source
+  and a global reference, publishes diagnostic statistics, and streams matching path markers.
+* **Alignment filter**: continuously aligns the local odometry frame to the global frame by running
+  a Kabsch-based optimization over a sliding window of localization monitor samples and optionally
+  publishes the transform as TF.
+* **NavSat preprocessing node**: fuses GNSS odometry with external heading estimates before feeding
+  them into the filters and optionally emits an IMU message with the corrected orientation.
+* **Launch and visualization assets**: a turnkey launch file to start the full monitoring pipeline
+  in ROS 2 and RViz layouts to inspect trajectories, diagnostics, and alignment results.
+
+### Launch and scripting support
+
+- `localization_monitor.launch.py` starts the full AIS monitoring pipeline and exposes launch
+  arguments to toggle the navsat preprocessing, alignment filter, and navsat transform stages or to
+  remap the involved topics.
+- `localization_monitor_node.launch.py`, `alignment_filter.launch.py`, and
+  `navsat_preprocessing.launch.py` provide component-level launch files for targeted debugging or
+  integration into larger applications.
+- Parameter presets for each component live in `params/localization_monitor.yaml`,
+  `params/alignment_filter.yaml`, and `params/navsat_preprocessing.yaml` and can be overridden with
+  custom YAML files.
+- `scripts/localization_monitor_pipeline.sh` mirrors the ROS 1 byobu helpers by creating a tmux
+  session that launches the pipeline (with optional arguments) and opens RViz with the
+  `config/MonitorAnalysis.rviz` layout when available. A focused configuration for alignment
+  debugging lives in `config/AlignmentFilter.rviz`.
+

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ This fork adds ROS 2 ports of AIS-specific tools that were previously only avail
 ### Launch and scripting support
 
 - `localization_monitor.launch.py` starts the full AIS monitoring pipeline and exposes launch
-  arguments to toggle the navsat preprocessing, alignment filter, and navsat transform stages or to
-  remap the involved topics.
+  arguments to toggle the navsat preprocessing, alignment filter, navsat transform stages, or RViz
+  as well as to remap the involved topics.
 - `localization_monitor_node.launch.py`, `alignment_filter.launch.py`, and
   `navsat_preprocessing.launch.py` provide component-level launch files for targeted debugging or
   integration into larger applications.
@@ -33,6 +33,7 @@ This fork adds ROS 2 ports of AIS-specific tools that were previously only avail
   custom YAML files.
 - `scripts/localization_monitor_pipeline.sh` mirrors the ROS 1 byobu helpers by creating a tmux
   session that launches the pipeline (with optional arguments) and opens RViz with the
-  `config/MonitorAnalysis.rviz` layout when available. A focused configuration for alignment
-  debugging lives in `config/AlignmentFilter.rviz`.
+  `config/MonitorAnalysis.rviz` layout when available. Pass `start_rviz:=false` if you want to skip
+  the visualization window. A focused configuration for alignment debugging lives in
+  `config/AlignmentFilter.rviz`.
 

--- a/config/AlignmentFilter.rviz
+++ b/config/AlignmentFilter.rviz
@@ -1,0 +1,249 @@
+Panels:
+  - Class: rviz/Displays
+    Help Height: 70
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /TF1
+        - /Aligned Odometry1/Shape1
+        - /Aligned Global Path1
+        - /Aligned Local Path1
+        - /Input Odometry1/Shape1
+      Splitter Ratio: 0.5
+    Tree Height: 705
+  - Class: rviz/Selection
+    Name: Selection
+  - Class: rviz/Tool Properties
+    Expanded:
+      - /2D Pose Estimate1
+      - /2D Nav Goal1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz/Time
+    Name: Time
+    SyncMode: 0
+    SyncSource: Aligned Odometry
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.029999999329447746
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: map
+      Value: true
+    - Class: rviz/TF
+      Enabled: true
+      Frame Timeout: 15
+      Marker Scale: 1
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: false
+      Tree:
+        map:
+          Value: true
+      Update Interval: 0
+      Value: true
+    - Angle Tolerance: 0.10000000149011612
+      Class: rviz/Odometry
+      Covariance:
+        Orientation:
+          Alpha: 0.5
+          Color: 255; 255; 127
+          Color Style: Unique
+          Frame: Local
+          Offset: 1
+          Scale: 1
+          Value: false
+        Position:
+          Alpha: 0.30000001192092896
+          Color: 204; 51; 204
+          Scale: 1
+          Value: false
+        Value: false
+      Enabled: true
+      Keep: 1
+      Name: Input Odometry
+      Position Tolerance: 0.10000000149011612
+      Queue Size: 10
+      Shape:
+        Alpha: 1
+        Axes Length: 1
+        Axes Radius: 0.10000000149011612
+        Color: 85; 255; 255
+        Head Length: 0.30000001192092896
+        Head Radius: 0.10000000149011612
+        Shaft Length: 1
+        Shaft Radius: 0.05000000074505806
+        Value: Arrow
+      Topic: /localization/odometry/odom_lidar
+      Unreliable: false
+      Value: true
+    - Angle Tolerance: 0.10000000149011612
+      Class: rviz/Odometry
+      Covariance:
+        Orientation:
+          Alpha: 0.5
+          Color: 255; 255; 127
+          Color Style: Unique
+          Frame: Local
+          Offset: 1
+          Scale: 1
+          Value: false
+        Position:
+          Alpha: 0.30000001192092896
+          Color: 204; 51; 204
+          Scale: 1
+          Value: false
+        Value: false
+      Enabled: true
+      Keep: 1
+      Name: Aligned Odometry
+      Position Tolerance: 0.10000000149011612
+      Queue Size: 10
+      Shape:
+        Alpha: 1
+        Axes Length: 1
+        Axes Radius: 0.10000000149011612
+        Color: 255; 85; 127
+        Head Length: 0.30000001192092896
+        Head Radius: 0.10000000149011612
+        Shaft Length: 1
+        Shaft Radius: 0.05000000074505806
+        Value: Arrow
+      Topic: /localization/alignment_filter/odom_map
+      Unreliable: false
+      Value: true
+    - Alpha: 1
+      Buffer Length: 1
+      Class: rviz/Path
+      Color: 255; 51; 51
+      Enabled: true
+      Head Diameter: 0.30000001192092896
+      Head Length: 0.20000000298023224
+      Length: 0.30000001192092896
+      Line Style: Lines
+      Line Width: 0.029999999329447746
+      Name: Aligned Global Path
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Pose Color: 255; 85; 255
+      Pose Style: None
+      Queue Size: 10
+      Radius: 0.029999999329447746
+      Shaft Diameter: 0.10000000149011612
+      Shaft Length: 0.10000000149011612
+      Topic: /localization/alignment_filter/global_path
+      Unreliable: false
+      Value: true
+    - Alpha: 1
+      Buffer Length: 1
+      Class: rviz/Path
+      Color: 51; 255; 51
+      Enabled: true
+      Head Diameter: 0.30000001192092896
+      Head Length: 0.20000000298023224
+      Length: 0.30000001192092896
+      Line Style: Lines
+      Line Width: 0.029999999329447746
+      Name: Aligned Local Path
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Pose Color: 255; 85; 255
+      Pose Style: None
+      Queue Size: 10
+      Radius: 0.029999999329447746
+      Shaft Diameter: 0.10000000149011612
+      Shaft Length: 0.10000000149011612
+      Topic: /localization/alignment_filter/local_path
+      Unreliable: false
+      Value: true
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Default Light: true
+    Fixed Frame: map
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz/Interact
+      Hide Inactive Objects: true
+    - Class: rviz/MoveCamera
+    - Class: rviz/Select
+    - Class: rviz/FocusCamera
+    - Class: rviz/Measure
+    - Class: rviz/SetInitialPose
+      Theta std deviation: 0.2617993950843811
+      Topic: /initialpose
+      X std deviation: 0.5
+      Y std deviation: 0.5
+    - Class: rviz/SetGoal
+      Topic: /move_base_simple/goal
+    - Class: rviz/PublishPoint
+      Single click: true
+      Topic: /clicked_point
+  Value: true
+  Views:
+    Current:
+      Class: rviz/Orbit
+      Distance: 30
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: 0
+        Y: 0
+        Z: 0
+      Focal Shape Fixed Size: true
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 0.7853981852531433
+      Target Frame: <Fixed Frame>
+      Value: Orbit (rviz)
+      Yaw: 0.7853981852531433
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 1016
+  Hide Left Dock: false
+  Hide Right Dock: false
+  QMainWindow State: 000000ff00000000fd00000004000000000000016a0000035afc020000000aff0000001200530065006c0065006300740069006f006e00000001e10000009b00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000b0fb000000120056006900650077007300200054006f006f02000001df000001ed00000185000000b0fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c00610079007301000000410000035a000000df00fffffffb0000000a00560069006500770073010000029f000000d5000000b000fffffffb0000001200530065006c0065006300740069006f006e010000025c000000b20000000000000000fb0000001c004d00650073007300610067006500730020005700690064006700650100000319000000810000000000000000fb000000200054006f006f006c002000500072006f0070006500720074006900650073010000039a0000004e000000000000000000000001000001420000035afc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000b00000000000000000fb0000000a00560069006500770073020000041a0000009d000002210000017afb0000001200530065006c0065006300740069006f006e020000025c000000b2000001b500000118fb0000000c00430061006d006500720061000000045a000000370000000000000000fb0000000c00430061006d006500720061010000045a0000003700000000000000000000000200000582000001ebfc0100000002fb0000000800540069006d00650100000000000005820000014c00fffffffb0000000800540069006d006501000000000000045a0000000000000000fb000000100044006900730070006c00610079007302000000410000035a00000138000000df00000001000001050000035afc0200000002fb0000000a0056006900650077007300000000000000035a000000b000ffffff00000001000001050000000000000000000000000000000000000000000000000400000142000000040000000400000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: false
+  Width: 1848
+  X: 72
+  Y: 27

--- a/config/MonitorAnalysis.rviz
+++ b/config/MonitorAnalysis.rviz
@@ -1,0 +1,439 @@
+Panels:
+  - Class: rviz/Displays
+    Help Height: 70
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Odometry1/Shape1
+        - /Odometry2/Shape1
+        - /Odometry5/Shape1
+      Splitter Ratio: 0.5
+    Tree Height: 705
+  - Class: rviz/Selection
+    Name: Selection
+  - Class: rviz/Tool Properties
+    Expanded:
+      - /2D Pose Estimate1
+      - /2D Nav Goal1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz/Time
+    Name: Time
+    SyncMode: 0
+    SyncSource: ""
+Preferences:
+  PromptSaveOnExit: true
+Toolbars:
+  toolButtonStyle: 2
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.029999999329447746
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Angle Tolerance: 0.10000000149011612
+      Class: rviz/Odometry
+      Covariance:
+        Orientation:
+          Alpha: 0.5
+          Color: 255; 255; 127
+          Color Style: Unique
+          Frame: Local
+          Offset: 1
+          Scale: 1
+          Value: true
+        Position:
+          Alpha: 0.30000001192092896
+          Color: 204; 51; 204
+          Scale: 1
+          Value: true
+        Value: true
+      Enabled: true
+      Keep: 1
+      Name: Odometry
+      Position Tolerance: 0.10000000149011612
+      Queue Size: 10
+      Shape:
+        Alpha: 1
+        Axes Length: 1
+        Axes Radius: 0.10000000149011612
+        Color: 255; 25; 0
+        Head Length: 0.30000001192092896
+        Head Radius: 0.10000000149011612
+        Shaft Length: 1
+        Shaft Radius: 0.05000000074505806
+        Value: Axes
+      Topic: /localization/odometry/odom_lidar
+      Unreliable: false
+      Value: true
+    - Angle Tolerance: 0.10000000149011612
+      Class: rviz/Odometry
+      Covariance:
+        Orientation:
+          Alpha: 0.5
+          Color: 255; 255; 127
+          Color Style: Unique
+          Frame: Local
+          Offset: 1
+          Scale: 1
+          Value: true
+        Position:
+          Alpha: 0.30000001192092896
+          Color: 204; 51; 204
+          Scale: 1
+          Value: true
+        Value: true
+      Enabled: true
+      Keep: 1
+      Name: Odometry
+      Position Tolerance: 0.10000000149011612
+      Queue Size: 10
+      Shape:
+        Alpha: 1
+        Axes Length: 1
+        Axes Radius: 0.10000000149011612
+        Color: 255; 85; 255
+        Head Length: 0.30000001192092896
+        Head Radius: 0.10000000149011612
+        Shaft Length: 1
+        Shaft Radius: 0.05000000074505806
+        Value: Arrow
+      Topic: /ground_truth
+      Unreliable: false
+      Value: true
+    - Angle Tolerance: 0.10000000149011612
+      Class: rviz/Odometry
+      Covariance:
+        Orientation:
+          Alpha: 0.5
+          Color: 255; 255; 127
+          Color Style: Unique
+          Frame: Local
+          Offset: 1
+          Scale: 1
+          Value: true
+        Position:
+          Alpha: 0.30000001192092896
+          Color: 204; 51; 204
+          Scale: 1
+          Value: true
+        Value: true
+      Enabled: true
+      Keep: 1
+      Name: Odometry
+      Position Tolerance: 0.10000000149011612
+      Queue Size: 10
+      Shape:
+        Alpha: 1
+        Axes Length: 1
+        Axes Radius: 0.10000000149011612
+        Color: 255; 25; 0
+        Head Length: 0.30000001192092896
+        Head Radius: 0.10000000149011612
+        Shaft Length: 1
+        Shaft Radius: 0.05000000074505806
+        Value: Arrow
+      Topic: /odom_gnss
+      Unreliable: false
+      Value: true
+    - Alpha: 1
+      Buffer Length: 1
+      Class: rviz/Path
+      Color: 25; 255; 0
+      Enabled: true
+      Head Diameter: 0.30000001192092896
+      Head Length: 0.20000000298023224
+      Length: 0.30000001192092896
+      Line Style: Lines
+      Line Width: 0.029999999329447746
+      Name: Path
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Pose Color: 255; 85; 255
+      Pose Style: Axes
+      Queue Size: 10
+      Radius: 0.029999999329447746
+      Shaft Diameter: 0.10000000149011612
+      Shaft Length: 0.10000000149011612
+      Topic: /localization/alignment_filter/local_path
+      Unreliable: false
+      Value: true
+    - Alpha: 1
+      Buffer Length: 1
+      Class: rviz/Path
+      Color: 255; 0; 0
+      Enabled: true
+      Head Diameter: 0.30000001192092896
+      Head Length: 0.20000000298023224
+      Length: 0.30000001192092896
+      Line Style: Lines
+      Line Width: 0.029999999329447746
+      Name: Path
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Pose Color: 255; 85; 255
+      Pose Style: Axes
+      Queue Size: 10
+      Radius: 0.029999999329447746
+      Shaft Diameter: 0.10000000149011612
+      Shaft Length: 0.10000000149011612
+      Topic: /localization/alignment_filter/global_path
+      Unreliable: false
+      Value: true
+    - Angle Tolerance: 0.10000000149011612
+      Class: rviz/Odometry
+      Covariance:
+        Orientation:
+          Alpha: 0.5
+          Color: 255; 255; 127
+          Color Style: Unique
+          Frame: Local
+          Offset: 1
+          Scale: 1
+          Value: true
+        Position:
+          Alpha: 0.30000001192092896
+          Color: 204; 51; 204
+          Scale: 1
+          Value: true
+        Value: true
+      Enabled: false
+      Keep: 1
+      Name: Odometry
+      Position Tolerance: 0.10000000149011612
+      Queue Size: 10
+      Shape:
+        Alpha: 1
+        Axes Length: 1
+        Axes Radius: 0.10000000149011612
+        Color: 255; 25; 0
+        Head Length: 0.30000001192092896
+        Head Radius: 0.10000000149011612
+        Shaft Length: 1
+        Shaft Radius: 0.05000000074505806
+        Value: Arrow
+      Topic: /localization/ekf/odom_filtered_map
+      Unreliable: false
+      Value: false
+    - Angle Tolerance: 0.10000000149011612
+      Class: rviz/Odometry
+      Covariance:
+        Orientation:
+          Alpha: 0.5
+          Color: 255; 255; 127
+          Color Style: Unique
+          Frame: Local
+          Offset: 1
+          Scale: 1
+          Value: true
+        Position:
+          Alpha: 0.30000001192092896
+          Color: 204; 51; 204
+          Scale: 1
+          Value: true
+        Value: false
+      Enabled: true
+      Keep: 1
+      Name: Odometry
+      Position Tolerance: 0.10000000149011612
+      Queue Size: 10
+      Shape:
+        Alpha: 1
+        Axes Length: 1
+        Axes Radius: 0.10000000149011612
+        Color: 85; 255; 0
+        Head Length: 0.30000001192092896
+        Head Radius: 0.10000000149011612
+        Shaft Length: 1
+        Shaft Radius: 0.05000000074505806
+        Value: Arrow
+      Topic: /transform_filtered_odom
+      Unreliable: false
+      Value: true
+    - Alpha: 1
+      Buffer Length: 1
+      Class: rviz/Path
+      Color: 255; 0; 0
+      Enabled: false
+      Head Diameter: 0.30000001192092896
+      Head Length: 0.20000000298023224
+      Length: 0.30000001192092896
+      Line Style: Lines
+      Line Width: 0.029999999329447746
+      Name: Path
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Pose Color: 255; 85; 255
+      Pose Style: Axes
+      Queue Size: 10
+      Radius: 0.029999999329447746
+      Shaft Diameter: 0.10000000149011612
+      Shaft Length: 0.10000000149011612
+      Topic: /localization/monitor/global_reference_path
+      Unreliable: false
+      Value: false
+    - Alpha: 1
+      Buffer Length: 1
+      Class: rviz/Path
+      Color: 25; 255; 0
+      Enabled: true
+      Head Diameter: 0.30000001192092896
+      Head Length: 0.20000000298023224
+      Length: 0.30000001192092896
+      Line Style: Lines
+      Line Width: 0.029999999329447746
+      Name: Path
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Pose Color: 255; 85; 255
+      Pose Style: None
+      Queue Size: 10
+      Radius: 0.029999999329447746
+      Shaft Diameter: 0.10000000149011612
+      Shaft Length: 0.10000000149011612
+      Topic: /localization/monitor/local_reference_path
+      Unreliable: false
+      Value: true
+    - Alpha: 1
+      Buffer Length: 1
+      Class: rviz/Path
+      Color: 0; 0; 255
+      Enabled: false
+      Head Diameter: 0.30000001192092896
+      Head Length: 0.20000000298023224
+      Length: 0.30000001192092896
+      Line Style: Lines
+      Line Width: 0.029999999329447746
+      Name: Path
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Pose Color: 255; 85; 255
+      Pose Style: None
+      Queue Size: 10
+      Radius: 0.029999999329447746
+      Shaft Diameter: 0.10000000149011612
+      Shaft Length: 0.10000000149011612
+      Topic: /localization/monitor_py/global_reference_path
+      Unreliable: false
+      Value: false
+    - Alpha: 1
+      Buffer Length: 1
+      Class: rviz/Path
+      Color: 255; 85; 127
+      Enabled: true
+      Head Diameter: 0.30000001192092896
+      Head Length: 0.20000000298023224
+      Length: 0.30000001192092896
+      Line Style: Billboards
+      Line Width: 0.029999999329447746
+      Name: Path
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Pose Color: 255; 85; 255
+      Pose Style: None
+      Queue Size: 10
+      Radius: 0.029999999329447746
+      Shaft Diameter: 0.10000000149011612
+      Shaft Length: 0.10000000149011612
+      Topic: /localization/monitor_py/local_reference_path
+      Unreliable: false
+      Value: true
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Default Light: true
+    Fixed Frame: map
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz/Interact
+      Hide Inactive Objects: true
+    - Class: rviz/MoveCamera
+    - Class: rviz/Select
+    - Class: rviz/FocusCamera
+    - Class: rviz/Measure
+    - Class: rviz/SetInitialPose
+      Theta std deviation: 0.2617993950843811
+      Topic: /initialpose
+      X std deviation: 0.5
+      Y std deviation: 0.5
+    - Class: rviz/SetGoal
+      Topic: /move_base_simple/goal
+    - Class: rviz/PublishPoint
+      Single click: true
+      Topic: /clicked_point
+  Value: true
+  Views:
+    Current:
+      Class: rviz/XYOrbit
+      Distance: 25.367717742919922
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Field of View: 0.7853981852531433
+      Focal Point:
+        X: 0
+        Y: 0
+        Z: 0
+      Focal Shape Fixed Size: false
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 0.7947964668273926
+      Target Frame: base_link
+      Yaw: 1.1354036331176758
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 988
+  Hide Left Dock: false
+  Hide Right Dock: false
+  QMainWindow State: 000000ff00000000fd0000000400000000000002b000000342fc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000005fb000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003b00000342000000c700fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f00000342fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000003b00000342000000a000fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000007740000003efc0100000002fb0000000800540069006d00650100000000000007740000030700fffffffb0000000800540069006d00650100000000000004500000000000000000000003a90000034200000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: false
+  Width: 1908
+  X: 45
+  Y: 0

--- a/include/ais_robot_localization/alignment_filter.hpp
+++ b/include/ais_robot_localization/alignment_filter.hpp
@@ -1,0 +1,60 @@
+#ifndef AIS_ROBOT_LOCALIZATION_ALIGNMENT_FILTER_HPP
+#define AIS_ROBOT_LOCALIZATION_ALIGNMENT_FILTER_HPP
+
+#include <cstddef>
+#include <vector>
+
+#include <Eigen/Geometry>
+
+namespace ais_robot_localization
+{
+struct AlignmentResult
+{
+  Eigen::Isometry3d transform{Eigen::Isometry3d::Identity()};
+  std::vector<Eigen::Isometry3d> transformed_local;
+  double used_length{0.0};
+};
+
+class AlignmentFilter
+{
+public:
+  AlignmentFilter();
+
+  void setMaxWindowLength(double length);
+
+  std::size_t addMeasurement(
+    const Eigen::Isometry3d & global_pose,
+    const Eigen::Isometry3d & local_pose,
+    double timestamp_sec,
+    double translational_error,
+    double cumulative_length);
+
+  bool hasSufficientData() const;
+
+  bool computeAlignment(AlignmentResult & result);
+
+  const std::vector<Eigen::Isometry3d> & globalPoses() const {return global_poses_;}
+  const std::vector<Eigen::Isometry3d> & localPoses() const {return local_poses_;}
+  const std::vector<double> & timestamps() const {return timestamps_;}
+  const std::vector<double> & translationalErrors() const {return translational_errors_;}
+  const Eigen::Isometry3d & currentTransform() const {return current_transform_;}
+  double usedLength() const {return used_length_;}
+
+private:
+  std::size_t cleanup();
+  static double percentile(const std::vector<double> & values, double percent);
+
+  double max_window_length_;
+  std::vector<Eigen::Isometry3d> global_poses_;
+  std::vector<Eigen::Isometry3d> local_poses_;
+  std::vector<double> timestamps_;
+  std::vector<double> translational_errors_;
+  std::vector<double> cumulative_lengths_;
+
+  Eigen::Isometry3d current_transform_;
+  double used_length_;
+};
+
+}  // namespace ais_robot_localization
+
+#endif  // AIS_ROBOT_LOCALIZATION_ALIGNMENT_FILTER_HPP

--- a/include/ais_robot_localization/localization_monitor.hpp
+++ b/include/ais_robot_localization/localization_monitor.hpp
@@ -1,0 +1,34 @@
+#ifndef AIS_ROBOT_LOCALIZATION_LOCALIZATION_MONITOR_HPP
+#define AIS_ROBOT_LOCALIZATION_LOCALIZATION_MONITOR_HPP
+
+#include <cstddef>
+#include <vector>
+
+#include <Eigen/Geometry>
+
+namespace ais_robot_localization
+{
+void checkCumulativeDistance(
+  std::vector<Eigen::Isometry3d> & local_poses,
+  std::vector<double> & local_times,
+  double & cumulative_distance,
+  double dist_cum_threshold,
+  std::size_t max_poses_threshold);
+
+void cleanupGlobalOdomPoses(
+  std::vector<Eigen::Isometry3d> & global_poses,
+  std::vector<double> & global_times,
+  const std::vector<double> & local_times);
+
+std::size_t findNearestTime(const std::vector<double> & times, double ref_time);
+
+void findCorrespondingPoses(
+  const std::vector<double> & local_times,
+  const std::vector<Eigen::Isometry3d> & global_poses,
+  const std::vector<double> & global_times,
+  std::vector<Eigen::Isometry3d> & aligned_poses,
+  std::vector<double> & aligned_times);
+
+}  // namespace ais_robot_localization
+
+#endif  // AIS_ROBOT_LOCALIZATION_LOCALIZATION_MONITOR_HPP

--- a/include/ais_robot_localization/se3_algorithms.hpp
+++ b/include/ais_robot_localization/se3_algorithms.hpp
@@ -1,0 +1,57 @@
+#ifndef AIS_ROBOT_LOCALIZATION_SE3_ALGORITHMS_HPP
+#define AIS_ROBOT_LOCALIZATION_SE3_ALGORITHMS_HPP
+
+#include <vector>
+
+#include <Eigen/Dense>
+#include <Eigen/Geometry>
+
+namespace ais_robot_localization
+{
+struct PoseStamped
+{
+  double stamp{0.0};
+  Eigen::Vector3d position{Eigen::Vector3d::Zero()};
+  Eigen::Quaterniond orientation{Eigen::Quaterniond::Identity()};
+};
+
+Eigen::Isometry3d odomToSE3(const Eigen::Vector3d & position, const Eigen::Quaterniond & orientation);
+
+PoseStamped se3ToPoseStamped(
+  const Eigen::Isometry3d & transform,
+  double stamp,
+  bool z_to_zero = false);
+
+double calculateEuclideanDistance(const Eigen::Isometry3d & pose1, const Eigen::Isometry3d & pose2);
+
+std::vector<double> gaussianWeights(const std::vector<double> & errors, double half_life);
+
+void kabschAlgorithm(
+  const std::vector<Eigen::Vector3d> & src,
+  const std::vector<Eigen::Vector3d> & dst,
+  Eigen::Matrix3d & rotation,
+  Eigen::Vector3d & translation,
+  const std::vector<double> * weights = nullptr);
+
+void makeSnake(std::vector<Eigen::Isometry3d> & trajectory, double fatness = 3.0);
+
+Eigen::Isometry3d alignTrajectories(
+  std::vector<Eigen::Isometry3d> & trajectory,
+  const std::vector<Eigen::Isometry3d> & reference,
+  const std::vector<double> * weights = nullptr);
+
+struct RPEStats
+{
+  double avg_trans{0.0};
+  double avg_rot{0.0};
+  double max_trans{0.0};
+  double max_rot{0.0};
+};
+
+RPEStats calculateRPE(
+  const std::vector<Eigen::Isometry3d> & reference,
+  const std::vector<Eigen::Isometry3d> & comparison);
+
+}  // namespace ais_robot_localization
+
+#endif  // AIS_ROBOT_LOCALIZATION_SE3_ALGORITHMS_HPP

--- a/launch/alignment_filter.launch.py
+++ b/launch/alignment_filter.launch.py
@@ -1,0 +1,73 @@
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description() -> LaunchDescription:
+    use_sim_time = LaunchConfiguration('use_sim_time')
+    params_file = LaunchConfiguration('params_file')
+    local_odom_topic = LaunchConfiguration('local_odom_topic')
+    monitor_result_topic = LaunchConfiguration('monitor_result_topic')
+    alignment_odom_topic = LaunchConfiguration('alignment_odom_topic')
+    alignment_global_path_topic = LaunchConfiguration('alignment_global_path_topic')
+    alignment_local_path_topic = LaunchConfiguration('alignment_local_path_topic')
+
+    declare_use_sim_time = DeclareLaunchArgument(
+        'use_sim_time', default_value='false',
+        description='Use simulation clock if true.')
+    declare_params = DeclareLaunchArgument(
+        'params_file',
+        default_value=PathJoinSubstitution([
+            FindPackageShare('robot_localization'),
+            'params',
+            'alignment_filter.yaml',
+        ]),
+        description='Parameter file for the alignment filter node.')
+    declare_local_odom = DeclareLaunchArgument(
+        'local_odom_topic',
+        default_value='localization/odometry/odom_lidar',
+        description='Input topic for the locally referenced odometry.')
+    declare_monitor_result = DeclareLaunchArgument(
+        'monitor_result_topic',
+        default_value='localization/monitor/result',
+        description='Localization monitor result topic to listen to.')
+    declare_alignment_odom = DeclareLaunchArgument(
+        'alignment_odom_topic',
+        default_value='localization/alignment_filter/odom_map',
+        description='Output topic for the globally aligned odometry.')
+    declare_alignment_global_path = DeclareLaunchArgument(
+        'alignment_global_path_topic',
+        default_value='localization/alignment_filter/global_path',
+        description='Output topic for the global reference path used by the filter.')
+    declare_alignment_local_path = DeclareLaunchArgument(
+        'alignment_local_path_topic',
+        default_value='localization/alignment_filter/local_path',
+        description='Output topic for the transformed local path.')
+
+    alignment_filter = Node(
+        package='robot_localization',
+        executable='alignment_filter_node',
+        name='alignment_filter',
+        output='screen',
+        parameters=[params_file, {'use_sim_time': use_sim_time}],
+        remappings=[
+            ('local_odom', local_odom_topic),
+            ('localization_result', monitor_result_topic),
+            ('alignment_odometry', alignment_odom_topic),
+            ('alignment_global_path', alignment_global_path_topic),
+            ('alignment_local_path_transformed', alignment_local_path_topic),
+        ],
+    )
+
+    return LaunchDescription([
+        declare_use_sim_time,
+        declare_params,
+        declare_local_odom,
+        declare_monitor_result,
+        declare_alignment_odom,
+        declare_alignment_global_path,
+        declare_alignment_local_path,
+        alignment_filter,
+    ])

--- a/launch/localization_monitor.launch.py
+++ b/launch/localization_monitor.launch.py
@@ -34,6 +34,7 @@ def generate_launch_description() -> LaunchDescription:
     start_navsat_preprocessing = LaunchConfiguration('start_navsat_preprocessing')
     start_alignment_filter = LaunchConfiguration('start_alignment_filter')
     start_navsat_transform = LaunchConfiguration('start_navsat_transform')
+    start_rviz = LaunchConfiguration('start_rviz')
 
     declare_use_sim_time = DeclareLaunchArgument(
         'use_sim_time', default_value='false',
@@ -146,6 +147,10 @@ def generate_launch_description() -> LaunchDescription:
         'start_navsat_transform',
         default_value='true',
         description='Start the navsat_transform_node as part of the pipeline.')
+    declare_start_rviz = DeclareLaunchArgument(
+        'start_rviz',
+        default_value='true',
+        description='Request RViz to start when using the pipeline helper script.')
 
     localization_monitor = Node(
         package='robot_localization',
@@ -239,6 +244,7 @@ def generate_launch_description() -> LaunchDescription:
         declare_start_navsat_preprocessing,
         declare_start_alignment_filter,
         declare_start_navsat_transform,
+        declare_start_rviz,
         localization_monitor,
         navsat_preprocessing,
         alignment_filter,

--- a/launch/localization_monitor.launch.py
+++ b/launch/localization_monitor.launch.py
@@ -1,0 +1,246 @@
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, SetEnvironmentVariable
+from launch.conditions import IfCondition
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description() -> LaunchDescription:
+    use_sim_time = LaunchConfiguration('use_sim_time')
+    monitor_params = LaunchConfiguration('monitor_params')
+    alignment_params = LaunchConfiguration('alignment_params')
+    navsat_params = LaunchConfiguration('navsat_params')
+    navsat_transform_params = LaunchConfiguration('navsat_transform_params')
+
+    global_odom_topic = LaunchConfiguration('global_odom_topic')
+    local_odom_topic = LaunchConfiguration('local_odom_topic')
+    monitor_result_topic = LaunchConfiguration('monitor_result_topic')
+    monitor_rpe_topic = LaunchConfiguration('monitor_rpe_topic')
+    monitor_global_path_topic = LaunchConfiguration('monitor_global_path_topic')
+    monitor_local_path_topic = LaunchConfiguration('monitor_local_path_topic')
+    scaled_gps_topic = LaunchConfiguration('scaled_gps_topic')
+
+    navsat_input_topic = LaunchConfiguration('navsat_input_topic')
+    navsat_heading_topic = LaunchConfiguration('navsat_heading_topic')
+    navsat_output_topic = LaunchConfiguration('navsat_output_topic')
+    navsat_imu_topic = LaunchConfiguration('navsat_imu_topic')
+    navsat_fix_topic = LaunchConfiguration('navsat_fix_topic')
+
+    alignment_odom_topic = LaunchConfiguration('alignment_odom_topic')
+    alignment_global_path_topic = LaunchConfiguration('alignment_global_path_topic')
+    alignment_local_path_topic = LaunchConfiguration('alignment_local_path_topic')
+
+    start_navsat_preprocessing = LaunchConfiguration('start_navsat_preprocessing')
+    start_alignment_filter = LaunchConfiguration('start_alignment_filter')
+    start_navsat_transform = LaunchConfiguration('start_navsat_transform')
+
+    declare_use_sim_time = DeclareLaunchArgument(
+        'use_sim_time', default_value='false',
+        description='Use simulation clock if true.')
+    declare_monitor_params = DeclareLaunchArgument(
+        'monitor_params',
+        default_value=PathJoinSubstitution([
+            FindPackageShare('robot_localization'),
+            'params',
+            'localization_monitor.yaml',
+        ]),
+        description='Parameter file for the localization monitor node.')
+    declare_alignment_params = DeclareLaunchArgument(
+        'alignment_params',
+        default_value=PathJoinSubstitution([
+            FindPackageShare('robot_localization'),
+            'params',
+            'alignment_filter.yaml',
+        ]),
+        description='Parameter file for the alignment filter node.')
+    declare_navsat_params = DeclareLaunchArgument(
+        'navsat_params',
+        default_value=PathJoinSubstitution([
+            FindPackageShare('robot_localization'),
+            'params',
+            'navsat_preprocessing.yaml',
+        ]),
+        description='Parameter file for the navsat preprocessing node.')
+    declare_navsat_transform_params = DeclareLaunchArgument(
+        'navsat_transform_params',
+        default_value=PathJoinSubstitution([
+            FindPackageShare('robot_localization'),
+            'params',
+            'navsat_transform.yaml',
+        ]),
+        description='Parameter file for the navsat_transform_node.')
+
+    declare_global_odom = DeclareLaunchArgument(
+        'global_odom_topic',
+        default_value='localization/preprocessing/global_odom_fix_cov',
+        description='Globally referenced odometry topic to monitor.')
+    declare_local_odom = DeclareLaunchArgument(
+        'local_odom_topic',
+        default_value='localization/odometry/odom_lidar',
+        description='Locally referenced odometry topic to monitor and align.')
+    declare_monitor_result = DeclareLaunchArgument(
+        'monitor_result_topic',
+        default_value='localization/monitor/result',
+        description='Output topic for aggregated monitor statistics.')
+    declare_monitor_rpe = DeclareLaunchArgument(
+        'monitor_rpe_topic',
+        default_value='localization/monitor/RPE_Values',
+        description='Output topic for RPE feature vectors.')
+    declare_monitor_global_path = DeclareLaunchArgument(
+        'monitor_global_path_topic',
+        default_value='localization/monitor/global_reference_path',
+        description='Output topic for the global reference path.')
+    declare_monitor_local_path = DeclareLaunchArgument(
+        'monitor_local_path_topic',
+        default_value='localization/monitor/local_reference_path',
+        description='Output topic for the transformed local path.')
+    declare_scaled_gps = DeclareLaunchArgument(
+        'scaled_gps_topic',
+        default_value='localization/monitor/gnss_with_scaled_covariance',
+        description='Output topic for the GNSS message with scaled covariance.')
+
+    declare_navsat_input = DeclareLaunchArgument(
+        'navsat_input_topic',
+        default_value='localization/navsat/odometry/gps',
+        description='Input odometry topic for navsat preprocessing and transform nodes.')
+    declare_navsat_heading = DeclareLaunchArgument(
+        'navsat_heading_topic',
+        default_value='navsat/orientation',
+        description='Heading topic for the navsat preprocessing node.')
+    declare_navsat_output = DeclareLaunchArgument(
+        'navsat_output_topic',
+        default_value='localization/preprocessing/global_odom_fix_cov',
+        description='Output odometry topic for navsat preprocessing and navsat transform.')
+    declare_navsat_imu = DeclareLaunchArgument(
+        'navsat_imu_topic',
+        default_value='localization/preprocessing/global_orientation_fix_cov',
+        description='Output IMU topic containing the corrected orientation.')
+    declare_navsat_fix = DeclareLaunchArgument(
+        'navsat_fix_topic',
+        default_value='navsat/fix',
+        description='Raw NavSatFix topic for the navsat transform node.')
+
+    declare_alignment_odom = DeclareLaunchArgument(
+        'alignment_odom_topic',
+        default_value='localization/alignment_filter/odom_map',
+        description='Output odometry topic for the alignment filter.')
+    declare_alignment_global_path = DeclareLaunchArgument(
+        'alignment_global_path_topic',
+        default_value='localization/alignment_filter/global_path',
+        description='Output topic for the alignment filter global path.')
+    declare_alignment_local_path = DeclareLaunchArgument(
+        'alignment_local_path_topic',
+        default_value='localization/alignment_filter/local_path',
+        description='Output topic for the transformed local path.')
+
+    declare_start_navsat_preprocessing = DeclareLaunchArgument(
+        'start_navsat_preprocessing',
+        default_value='true',
+        description='Start the navsat preprocessing node as part of the pipeline.')
+    declare_start_alignment_filter = DeclareLaunchArgument(
+        'start_alignment_filter',
+        default_value='true',
+        description='Start the alignment filter node as part of the pipeline.')
+    declare_start_navsat_transform = DeclareLaunchArgument(
+        'start_navsat_transform',
+        default_value='true',
+        description='Start the navsat_transform_node as part of the pipeline.')
+
+    localization_monitor = Node(
+        package='robot_localization',
+        executable='localization_monitor_node',
+        name='localization_monitor',
+        output='screen',
+        parameters=[monitor_params, {'use_sim_time': use_sim_time}],
+        remappings=[
+            ('global_odom', global_odom_topic),
+            ('local_odom', local_odom_topic),
+            ('global_odom_path', monitor_global_path_topic),
+            ('local_odom_path', monitor_local_path_topic),
+            ('localization_result', monitor_result_topic),
+            ('RPE_Values', monitor_rpe_topic),
+            ('gnss_with_scaled_covariance', scaled_gps_topic),
+        ],
+    )
+
+    alignment_filter = Node(
+        package='robot_localization',
+        executable='alignment_filter_node',
+        name='alignment_filter',
+        output='screen',
+        parameters=[alignment_params, {'use_sim_time': use_sim_time}],
+        remappings=[
+            ('local_odom', local_odom_topic),
+            ('localization_result', monitor_result_topic),
+            ('alignment_odometry', alignment_odom_topic),
+            ('alignment_global_path', alignment_global_path_topic),
+            ('alignment_local_path_transformed', alignment_local_path_topic),
+        ],
+        condition=IfCondition(start_alignment_filter),
+    )
+
+    navsat_preprocessing = Node(
+        package='robot_localization',
+        executable='navsat_preprocessing_node.py',
+        name='navsat_preprocessing',
+        output='screen',
+        parameters=[navsat_params, {'use_sim_time': use_sim_time}],
+        remappings=[
+            ('localization/preprocessing/input/gps_odometry', navsat_input_topic),
+            (
+                'localization/preprocessing/input/orientation_with_global_heading',
+                navsat_heading_topic,
+            ),
+            ('localization/preprocessing/output/odometry', navsat_output_topic),
+            ('localization/preprocessing/output/imu_with_fix_cov', navsat_imu_topic),
+        ],
+        condition=IfCondition(start_navsat_preprocessing),
+    )
+
+    navsat_transform = Node(
+        package='robot_localization',
+        executable='navsat_transform_node',
+        name='navsat_transform_node',
+        output='screen',
+        parameters=[navsat_transform_params, {'use_sim_time': use_sim_time}],
+        remappings=[
+            ('odometry/filtered', alignment_odom_topic),
+            ('gps/fix', navsat_fix_topic),
+            ('odometry/gps', navsat_input_topic),
+            ('gps/filtered', navsat_output_topic),
+            ('imu/data', navsat_imu_topic),
+        ],
+        condition=IfCondition(start_navsat_transform),
+    )
+
+    return LaunchDescription([
+        SetEnvironmentVariable('RCUTILS_COLORIZED_OUTPUT', '1'),
+        declare_use_sim_time,
+        declare_monitor_params,
+        declare_alignment_params,
+        declare_navsat_params,
+        declare_navsat_transform_params,
+        declare_global_odom,
+        declare_local_odom,
+        declare_monitor_result,
+        declare_monitor_rpe,
+        declare_monitor_global_path,
+        declare_monitor_local_path,
+        declare_scaled_gps,
+        declare_navsat_input,
+        declare_navsat_heading,
+        declare_navsat_output,
+        declare_navsat_imu,
+        declare_navsat_fix,
+        declare_alignment_odom,
+        declare_alignment_global_path,
+        declare_alignment_local_path,
+        declare_start_navsat_preprocessing,
+        declare_start_alignment_filter,
+        declare_start_navsat_transform,
+        localization_monitor,
+        navsat_preprocessing,
+        alignment_filter,
+        navsat_transform,
+    ])

--- a/launch/localization_monitor_node.launch.py
+++ b/launch/localization_monitor_node.launch.py
@@ -1,0 +1,87 @@
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description() -> LaunchDescription:
+    use_sim_time = LaunchConfiguration('use_sim_time')
+    params_file = LaunchConfiguration('params_file')
+    global_odom_topic = LaunchConfiguration('global_odom_topic')
+    local_odom_topic = LaunchConfiguration('local_odom_topic')
+    global_path_topic = LaunchConfiguration('global_path_topic')
+    local_path_topic = LaunchConfiguration('local_path_topic')
+    monitor_result_topic = LaunchConfiguration('monitor_result_topic')
+    rpe_topic = LaunchConfiguration('rpe_topic')
+    scaled_gps_topic = LaunchConfiguration('scaled_gps_topic')
+
+    declare_use_sim_time = DeclareLaunchArgument(
+        'use_sim_time', default_value='false',
+        description='Use simulation clock if true.')
+    declare_params = DeclareLaunchArgument(
+        'params_file',
+        default_value=PathJoinSubstitution([
+            FindPackageShare('robot_localization'),
+            'params',
+            'localization_monitor.yaml',
+        ]),
+        description='Parameter file for the localization monitor node.')
+    declare_global_odom = DeclareLaunchArgument(
+        'global_odom_topic',
+        default_value='localization/preprocessing/global_odom_fix_cov',
+        description='Globally referenced odometry topic to monitor.')
+    declare_local_odom = DeclareLaunchArgument(
+        'local_odom_topic',
+        default_value='localization/odometry/odom_lidar',
+        description='Locally referenced odometry topic to monitor.')
+    declare_global_path = DeclareLaunchArgument(
+        'global_path_topic',
+        default_value='localization/monitor/global_reference_path',
+        description='Output topic for the global reference path.')
+    declare_local_path = DeclareLaunchArgument(
+        'local_path_topic',
+        default_value='localization/monitor/local_reference_path',
+        description='Output topic for the transformed local path.')
+    declare_monitor_result = DeclareLaunchArgument(
+        'monitor_result_topic',
+        default_value='localization/monitor/result',
+        description='Output topic for aggregated monitor statistics.')
+    declare_rpe_topic = DeclareLaunchArgument(
+        'rpe_topic',
+        default_value='localization/monitor/RPE_Values',
+        description='Output topic for RPE feature vectors.')
+    declare_scaled_gps = DeclareLaunchArgument(
+        'scaled_gps_topic',
+        default_value='localization/monitor/gnss_with_scaled_covariance',
+        description='Output topic for the GNSS message with scaled covariance.')
+
+    localization_monitor = Node(
+        package='robot_localization',
+        executable='localization_monitor_node',
+        name='localization_monitor',
+        output='screen',
+        parameters=[params_file, {'use_sim_time': use_sim_time}],
+        remappings=[
+            ('global_odom', global_odom_topic),
+            ('local_odom', local_odom_topic),
+            ('global_odom_path', global_path_topic),
+            ('local_odom_path', local_path_topic),
+            ('localization_result', monitor_result_topic),
+            ('RPE_Values', rpe_topic),
+            ('gnss_with_scaled_covariance', scaled_gps_topic),
+        ],
+    )
+
+    return LaunchDescription([
+        declare_use_sim_time,
+        declare_params,
+        declare_global_odom,
+        declare_local_odom,
+        declare_global_path,
+        declare_local_path,
+        declare_monitor_result,
+        declare_rpe_topic,
+        declare_scaled_gps,
+        localization_monitor,
+    ])

--- a/launch/navsat_preprocessing.launch.py
+++ b/launch/navsat_preprocessing.launch.py
@@ -1,0 +1,69 @@
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description() -> LaunchDescription:
+    use_sim_time = LaunchConfiguration('use_sim_time')
+    params_file = LaunchConfiguration('params_file')
+    gps_topic = LaunchConfiguration('gps_topic')
+    heading_topic = LaunchConfiguration('heading_topic')
+    odometry_output_topic = LaunchConfiguration('odometry_output_topic')
+    imu_output_topic = LaunchConfiguration('imu_output_topic')
+
+    declare_use_sim_time = DeclareLaunchArgument(
+        'use_sim_time', default_value='false',
+        description='Use simulation clock if true.')
+    declare_params_file = DeclareLaunchArgument(
+        'params_file',
+        default_value=PathJoinSubstitution([
+            FindPackageShare('robot_localization'),
+            'params',
+            'navsat_preprocessing.yaml',
+        ]),
+        description='Parameter file for the navsat preprocessing node.')
+    declare_gps_topic = DeclareLaunchArgument(
+        'gps_topic',
+        default_value='localization/navsat/odometry/gps',
+        description='Topic providing GNSS odometry messages.')
+    declare_heading_topic = DeclareLaunchArgument(
+        'heading_topic',
+        default_value='navsat/orientation',
+        description='Topic providing heading information as QuaternionStamped.')
+    declare_odometry_output = DeclareLaunchArgument(
+        'odometry_output_topic',
+        default_value='localization/preprocessing/global_odom_fix_cov',
+        description='Output topic for the fused global odometry.')
+    declare_imu_output = DeclareLaunchArgument(
+        'imu_output_topic',
+        default_value='localization/preprocessing/global_orientation_fix_cov',
+        description='Optional IMU topic with the corrected orientation.')
+
+    navsat_preprocessing = Node(
+        package='robot_localization',
+        executable='navsat_preprocessing_node.py',
+        name='navsat_preprocessing',
+        output='screen',
+        parameters=[params_file, {'use_sim_time': use_sim_time}],
+        remappings=[
+            ('localization/preprocessing/input/gps_odometry', gps_topic),
+            (
+                'localization/preprocessing/input/orientation_with_global_heading',
+                heading_topic,
+            ),
+            ('localization/preprocessing/output/odometry', odometry_output_topic),
+            ('localization/preprocessing/output/imu_with_fix_cov', imu_output_topic),
+        ],
+    )
+
+    return LaunchDescription([
+        declare_use_sim_time,
+        declare_params_file,
+        declare_gps_topic,
+        declare_heading_topic,
+        declare_odometry_output,
+        declare_imu_output,
+        navsat_preprocessing,
+    ])

--- a/msg/LocalizationMonitorResult.msg
+++ b/msg/LocalizationMonitorResult.msg
@@ -1,0 +1,4 @@
+float32[] float_array
+geometry_msgs/PoseStamped pose_global
+geometry_msgs/PoseStamped pose_local
+float64 cumulative_length

--- a/package.xml
+++ b/package.xml
@@ -43,9 +43,11 @@
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>builtin_interfaces</test_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
-  
+
   <exec_depend>rclcpp</exec_depend>
+  <exec_depend>rclpy</exec_depend>
   <exec_depend>rmw_implementation</exec_depend>
+  <exec_depend>tf_transformations</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/params/alignment_filter.yaml
+++ b/params/alignment_filter.yaml
@@ -1,0 +1,5 @@
+alignment_filter:
+  ros__parameters:
+    publish_tf: true
+    global_frame: map
+    local_frame: odom

--- a/params/localization_monitor.yaml
+++ b/params/localization_monitor.yaml
@@ -1,0 +1,9 @@
+localization_monitor:
+  ros__parameters:
+    dist_cum_threshold: 15.0
+    publish_rate: 0.5
+    max_poses_threshold: 500
+    time_based: false
+    publish_gnss_with_scaled_covariance: false
+    global_frame: map
+    local_frame: odom

--- a/params/navsat_preprocessing.yaml
+++ b/params/navsat_preprocessing.yaml
@@ -1,0 +1,16 @@
+navsat_preprocessing:
+  ros__parameters:
+    base_link_frame: base_link
+    use_external_heading: true
+    calculate_heading_from_trajectory: false
+    overwrite_covariance_matrix: false
+    heading_reference_length: 10.0
+    publish_imu_message_with_orientation: true
+    pose_covariance: [
+      1000.0, 0.0,   0.0,   0.0, 0.0, 0.0,
+      0.0,   1000.0, 0.0,   0.0, 0.0, 0.0,
+      0.0,   0.0,   1500.0, 0.0, 0.0, 0.0,
+      0.0,   0.0,      0.0, 0.5, 0.0, 0.0,
+      0.0,   0.0,      0.0, 0.0, 0.5, 0.0,
+      0.0,   0.0,      0.0, 0.0, 0.0, 0.5
+    ]

--- a/scripts/localization_monitor_pipeline.sh
+++ b/scripts/localization_monitor_pipeline.sh
@@ -5,6 +5,18 @@ SESSION_NAME="ais_localization_pipeline"
 PIPELINE_WINDOW="pipeline"
 RVIZ_WINDOW="rviz"
 LAUNCH_ARGS=("$@")
+START_RVIZ=true
+
+for arg in "${LAUNCH_ARGS[@]}"; do
+  case "${arg}" in
+    start_rviz:=false|start_rviz:=False|start_rviz:=FALSE)
+      START_RVIZ=false
+      ;;
+    start_rviz:=true|start_rviz:=True|start_rviz:=TRUE)
+      START_RVIZ=true
+      ;;
+  esac
+done
 
 if ! command -v tmux >/dev/null 2>&1; then
   echo "tmux is required to run this script." >&2
@@ -25,11 +37,11 @@ pkg_prefix=$(ros2 pkg prefix robot_localization)
 pkg_share="${pkg_prefix}/share/robot_localization"
 rviz_config="${pkg_share}/config/MonitorAnalysis.rviz"
 
-if ! command -v rviz2 >/dev/null 2>&1; then
-  echo "rviz2 was not found in PATH. The pipeline will start without visualization." >&2
-  start_rviz=false
-else
-  start_rviz=true
+if [ "${START_RVIZ}" = true ]; then
+  if ! command -v rviz2 >/dev/null 2>&1; then
+    echo "rviz2 was not found in PATH. The pipeline will start without visualization." >&2
+    START_RVIZ=false
+  fi
 fi
 
 # Start tmux session with the pipeline launch
@@ -41,7 +53,7 @@ fi
 
 tmux set-option -t "${SESSION_NAME}" remain-on-exit on
 
-if [ "${start_rviz}" = true ] && [ -f "${rviz_config}" ]; then
+if [ "${START_RVIZ}" = true ] && [ -f "${rviz_config}" ]; then
   tmux new-window -t "${SESSION_NAME}" -n "${RVIZ_WINDOW}" "rviz2 -d ${rviz_config}"
 fi
 

--- a/scripts/localization_monitor_pipeline.sh
+++ b/scripts/localization_monitor_pipeline.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SESSION_NAME="ais_localization_pipeline"
+PIPELINE_WINDOW="pipeline"
+RVIZ_WINDOW="rviz"
+LAUNCH_ARGS=("$@")
+
+if ! command -v tmux >/dev/null 2>&1; then
+  echo "tmux is required to run this script." >&2
+  exit 1
+fi
+
+if ! command -v ros2 >/dev/null 2>&1; then
+  echo "ros2 CLI is not available in the current environment." >&2
+  exit 1
+fi
+
+if tmux has-session -t "${SESSION_NAME}" 2>/dev/null; then
+  echo "A tmux session named ${SESSION_NAME} is already running. Attach to it with 'tmux attach -t ${SESSION_NAME}'." >&2
+  exit 1
+fi
+
+pkg_prefix=$(ros2 pkg prefix robot_localization)
+pkg_share="${pkg_prefix}/share/robot_localization"
+rviz_config="${pkg_share}/config/MonitorAnalysis.rviz"
+
+if ! command -v rviz2 >/dev/null 2>&1; then
+  echo "rviz2 was not found in PATH. The pipeline will start without visualization." >&2
+  start_rviz=false
+else
+  start_rviz=true
+fi
+
+# Start tmux session with the pipeline launch
+if [ ${#LAUNCH_ARGS[@]} -gt 0 ]; then
+  tmux new-session -d -s "${SESSION_NAME}" -n "${PIPELINE_WINDOW}" "ros2 launch robot_localization localization_monitor.launch.py ${LAUNCH_ARGS[*]}"
+else
+  tmux new-session -d -s "${SESSION_NAME}" -n "${PIPELINE_WINDOW}" "ros2 launch robot_localization localization_monitor.launch.py"
+fi
+
+tmux set-option -t "${SESSION_NAME}" remain-on-exit on
+
+if [ "${start_rviz}" = true ] && [ -f "${rviz_config}" ]; then
+  tmux new-window -t "${SESSION_NAME}" -n "${RVIZ_WINDOW}" "rviz2 -d ${rviz_config}"
+fi
+
+tmux select-window -t "${SESSION_NAME}:${PIPELINE_WINDOW}"
+tmux attach -t "${SESSION_NAME}"

--- a/scripts/navsat_preprocessing_node.py
+++ b/scripts/navsat_preprocessing_node.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+
+from typing import Optional, Sequence
+
+import rclpy
+from rclpy.node import Node
+from rclpy.publisher import Publisher
+from rclpy.subscription import Subscription
+
+from geometry_msgs.msg import Quaternion, QuaternionStamped
+from nav_msgs.msg import Odometry
+from sensor_msgs.msg import Imu
+
+import tf_transformations as tf_trans
+
+
+class NavsatPreprocessingNode(Node):
+    """Fuse GNSS odometry with an externally provided heading source."""
+
+    def __init__(self) -> None:
+        super().__init__('navsat_preprocessing_node')
+        self.get_logger().info('Initializing navsat preprocessing node...')
+        self.declare_parameter('use_sim_time', False)
+
+        self.base_link_frame = self.declare_parameter('base_link_frame', 'base_link').value
+        self.use_external_heading = self.declare_parameter('use_external_heading', True).value
+        self.calculate_heading_from_trajectory = self.declare_parameter(
+            'calculate_heading_from_trajectory', False).value
+        self.overwrite_covariance_matrix = self.declare_parameter(
+            'overwrite_covariance_matrix', False).value
+        self.heading_reference_length = float(self.declare_parameter('heading_reference_length', 10).value)
+        self.publish_imu_message_with_orientation = self.declare_parameter(
+            'publish_imu_message_with_orientation', False).value
+
+        default_covariance = [
+            1000.0, 0.0,   0.0,   0.0, 0.0, 0.0,
+            0.0,   1000.0, 0.0,   0.0, 0.0, 0.0,
+            0.0,   0.0,   1500.0, 0.0, 0.0, 0.0,
+            0.0,   0.0,     0.0,  0.5, 0.0, 0.0,
+            0.0,   0.0,     0.0,  0.0, 0.5, 0.0,
+            0.0,   0.0,     0.0,  0.0, 0.0, 0.5,
+        ]
+        self.pose_covariance = self.declare_parameter(
+            'pose_covariance', default_covariance).value  # type: ignore[assignment]
+
+        qos = rclpy.qos.QoSProfile(depth=10)
+        self.odom_sub = self.create_subscription(
+            Odometry,
+            'localization/preprocessing/input/gps_odometry',
+            self.odom_callback,
+            qos)
+
+        self.orientation_sub: Optional[Subscription] = None
+        if self.use_external_heading:
+            self.orientation_sub = self.create_subscription(
+                QuaternionStamped,
+                'localization/preprocessing/input/orientation_with_global_heading',
+                self.orientation_with_heading_callback,
+                qos)
+        elif self.calculate_heading_from_trajectory:
+            self.get_logger().error('calculate_heading_from_trajectory is not implemented yet')
+
+        self.odom_with_pose_pub = self.create_publisher(
+            Odometry, 'localization/preprocessing/output/odometry', 10)
+
+        self.imu_pub: Optional[Publisher] = None
+        if self.publish_imu_message_with_orientation:
+            self.imu_pub = self.create_publisher(
+                Imu, 'localization/preprocessing/output/imu_with_fix_cov', 10)
+
+        self.latest_odom: Optional[Odometry] = None
+        self.latest_orientation: Optional[QuaternionStamped] = None
+
+    def odom_callback(self, msg: Odometry) -> None:
+        self.latest_odom = msg
+        if self.latest_orientation is None:
+            return
+        self.publish_odom_with_pose_and_covariance()
+
+    def orientation_with_heading_callback(self, msg: QuaternionStamped) -> None:
+        self.latest_orientation = msg
+        if self.publish_imu_message_with_orientation and self.imu_pub is not None:
+            self.publish_imu_with_orientation()
+
+    def apply_static_transform(self, quaternion: Quaternion) -> Quaternion:
+        rotation_matrix = tf_trans.quaternion_matrix(
+            [quaternion.x, quaternion.y, quaternion.z, quaternion.w])
+
+        local_z_rotation = tf_trans.quaternion_matrix([0.0, 0.0, 0.0, 1.0])
+        rotated_matrix = tf_trans.concatenate_matrices(rotation_matrix, local_z_rotation)
+        rotated_quaternion = tf_trans.quaternion_from_matrix(rotated_matrix)
+        return Quaternion(x=rotated_quaternion[0], y=rotated_quaternion[1],
+                          z=rotated_quaternion[2], w=rotated_quaternion[3])
+
+    def publish_odom_with_pose_and_covariance(self) -> None:
+        if self.latest_odom is None or self.latest_orientation is None:
+            return
+
+        odom_with_pose = Odometry()
+        odom_with_pose.header = self.latest_odom.header
+        odom_with_pose.child_frame_id = self.base_link_frame
+        odom_with_pose.pose = self.latest_odom.pose
+
+        if self.overwrite_covariance_matrix:
+            odom_with_pose.pose.covariance = list(self.pose_covariance)
+
+        odom_with_pose.pose.pose.orientation = self.apply_static_transform(
+            self.latest_orientation.quaternion)
+
+        self.odom_with_pose_pub.publish(odom_with_pose)
+
+    def publish_imu_with_orientation(self) -> None:
+        if self.latest_orientation is None or self.imu_pub is None:
+            return
+
+        imu_msg = Imu()
+        imu_msg.header = self.latest_orientation.header
+        imu_msg.orientation = self.latest_orientation.quaternion
+        imu_msg.orientation_covariance = self._orientation_covariance_from_pose(self.pose_covariance)
+
+        self.imu_pub.publish(imu_msg)
+
+    @staticmethod
+    def _orientation_covariance_from_pose(covariance: Sequence[float]) -> Sequence[float]:
+        if len(covariance) >= 36:
+            return [
+                covariance[21], covariance[22], covariance[23],
+                covariance[27], covariance[28], covariance[29],
+                covariance[33], covariance[34], covariance[35],
+            ]
+        return [0.1, 0.0, 0.0, 0.0, 0.1, 0.0, 0.0, 0.0, 0.1]
+
+
+def main(args=None) -> None:
+    rclpy.init(args=args)
+    node = NavsatPreprocessingNode()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/alignment_filter.cpp
+++ b/src/alignment_filter.cpp
@@ -1,0 +1,128 @@
+#include "ais_robot_localization/alignment_filter.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+#include "ais_robot_localization/se3_algorithms.hpp"
+
+namespace ais_robot_localization
+{
+namespace
+{
+constexpr std::size_t kMinSamples = 4;
+constexpr double kDefaultWindowLength = 150.0;
+}  // namespace
+
+AlignmentFilter::AlignmentFilter()
+: max_window_length_(kDefaultWindowLength),
+  current_transform_(Eigen::Isometry3d::Identity()),
+  used_length_(0.0)
+{
+}
+
+void AlignmentFilter::setMaxWindowLength(double length)
+{
+  if (length > 0.0) {
+    max_window_length_ = length;
+  }
+}
+
+std::size_t AlignmentFilter::addMeasurement(
+  const Eigen::Isometry3d & global_pose,
+  const Eigen::Isometry3d & local_pose,
+  double timestamp_sec,
+  double translational_error,
+  double cumulative_length)
+{
+  global_poses_.push_back(global_pose);
+  local_poses_.push_back(local_pose);
+  timestamps_.push_back(timestamp_sec);
+  translational_errors_.push_back(translational_error);
+  cumulative_lengths_.push_back(cumulative_length);
+
+  std::size_t removed = cleanup();
+
+  if (cumulative_lengths_.size() >= 2) {
+    used_length_ = cumulative_lengths_.back() - cumulative_lengths_.front();
+  } else {
+    used_length_ = 0.0;
+  }
+
+  return removed;
+}
+
+bool AlignmentFilter::hasSufficientData() const
+{
+  return global_poses_.size() >= kMinSamples && local_poses_.size() >= kMinSamples;
+}
+
+bool AlignmentFilter::computeAlignment(AlignmentResult & result)
+{
+  if (!hasSufficientData()) {
+    return false;
+  }
+
+  std::vector<Eigen::Isometry3d> local_for_alignment = local_poses_;
+  std::vector<double> weights = gaussianWeights(translational_errors_, percentile(translational_errors_, 25.0));
+  const std::vector<double> * weights_ptr = nullptr;
+  if (weights.size() == local_for_alignment.size()) {
+    weights_ptr = &weights;
+  }
+
+  Eigen::Isometry3d transform = alignTrajectories(local_for_alignment, global_poses_, weights_ptr);
+
+  current_transform_ = transform;
+  result.transform = transform;
+  result.transformed_local = std::move(local_for_alignment);
+  result.used_length = used_length_;
+
+  return true;
+}
+
+std::size_t AlignmentFilter::cleanup()
+{
+  if (cumulative_lengths_.empty()) {
+    return 0U;
+  }
+
+  std::size_t removed = 0U;
+  while (cumulative_lengths_.size() > 1 &&
+    cumulative_lengths_.back() - cumulative_lengths_.front() > max_window_length_)
+  {
+    global_poses_.erase(global_poses_.begin());
+    local_poses_.erase(local_poses_.begin());
+    timestamps_.erase(timestamps_.begin());
+    translational_errors_.erase(translational_errors_.begin());
+    cumulative_lengths_.erase(cumulative_lengths_.begin());
+    ++removed;
+  }
+
+  return removed;
+}
+
+double AlignmentFilter::percentile(const std::vector<double> & values, double percent)
+{
+  if (values.empty()) {
+    return 0.0;
+  }
+
+  std::vector<double> sorted = values;
+  std::sort(sorted.begin(), sorted.end());
+
+  if (sorted.size() == 1U) {
+    return sorted.front();
+  }
+
+  double rank = percent / 100.0 * static_cast<double>(sorted.size() - 1U);
+  double lower_idx = std::floor(rank);
+  double upper_idx = std::ceil(rank);
+  double fraction = rank - lower_idx;
+
+  double lower_value = sorted[static_cast<std::size_t>(lower_idx)];
+  double upper_value = sorted[static_cast<std::size_t>(upper_idx)];
+
+  return lower_value + (upper_value - lower_value) * fraction;
+}
+
+}  // namespace ais_robot_localization
+

--- a/src/alignment_filter_node.cpp
+++ b/src/alignment_filter_node.cpp
@@ -1,0 +1,295 @@
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <geometry_msgs/msg/pose.hpp>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <geometry_msgs/msg/transform_stamped.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+#include <nav_msgs/msg/path.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/header.hpp>
+#include <tf2/exceptions.h>
+#include <tf2/time.h>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_broadcaster.h>
+#include <tf2_ros/transform_listener.h>
+
+#include "ais_robot_localization/alignment_filter.hpp"
+#include "ais_robot_localization/se3_algorithms.hpp"
+#include "robot_localization/msg/localization_monitor_result.hpp"
+
+namespace ais_robot_localization
+{
+namespace
+{
+
+Eigen::Quaterniond toEigenQuaternion(const geometry_msgs::msg::Quaternion & q_msg)
+{
+  Eigen::Quaterniond q(q_msg.w, q_msg.x, q_msg.y, q_msg.z);
+  if (q.norm() == 0.0) {
+    return Eigen::Quaterniond::Identity();
+  }
+  q.normalize();
+  return q;
+}
+
+Eigen::Isometry3d poseMsgToIsometry(const geometry_msgs::msg::Pose & pose_msg)
+{
+  Eigen::Vector3d position(pose_msg.position.x, pose_msg.position.y, pose_msg.position.z);
+  Eigen::Quaterniond orientation = toEigenQuaternion(pose_msg.orientation);
+  return odomToSE3(position, orientation);
+}
+
+geometry_msgs::msg::PoseStamped toRosPoseStamped(
+  const PoseStamped & pose,
+  const std::string & frame_id,
+  const rclcpp::Time & stamp)
+{
+  geometry_msgs::msg::PoseStamped msg;
+  msg.header.frame_id = frame_id;
+  msg.header.stamp = stamp;
+  msg.pose.position.x = pose.position.x();
+  msg.pose.position.y = pose.position.y();
+  msg.pose.position.z = pose.position.z();
+  msg.pose.orientation.x = pose.orientation.x();
+  msg.pose.orientation.y = pose.orientation.y();
+  msg.pose.orientation.z = pose.orientation.z();
+  msg.pose.orientation.w = pose.orientation.w();
+  return msg;
+}
+
+geometry_msgs::msg::Pose toRosPose(const Eigen::Isometry3d & transform)
+{
+  geometry_msgs::msg::Pose pose_msg;
+  Eigen::Quaterniond q(transform.linear());
+  q.normalize();
+  pose_msg.position.x = transform.translation().x();
+  pose_msg.position.y = transform.translation().y();
+  pose_msg.position.z = transform.translation().z();
+  pose_msg.orientation.x = q.x();
+  pose_msg.orientation.y = q.y();
+  pose_msg.orientation.z = q.z();
+  pose_msg.orientation.w = q.w();
+  return pose_msg;
+}
+
+rclcpp::Time secondsToTime(double stamp_sec)
+{
+  return rclcpp::Time(static_cast<int64_t>(stamp_sec * 1e9));
+}
+
+}  // namespace
+
+class AlignmentFilterNode : public rclcpp::Node
+{
+public:
+  AlignmentFilterNode()
+  : rclcpp::Node("alignment_filter_node"),
+    publish_tf_(this->declare_parameter("publish_tf", true)),
+    current_transform_(Eigen::Isometry3d::Identity())
+  {
+    global_frame_ = this->declare_parameter<std::string>("global_frame", "map");
+    local_frame_ = this->declare_parameter<std::string>("local_frame", "odom");
+
+    global_path_pub_ = this->create_publisher<nav_msgs::msg::Path>("alignment_global_path", 10);
+    local_path_transformed_pub_ =
+      this->create_publisher<nav_msgs::msg::Path>("alignment_local_path_transformed", 10);
+    odom_pub_ = this->create_publisher<nav_msgs::msg::Odometry>("alignment_odometry", 10);
+
+    localization_result_sub_ = this->create_subscription<robot_localization::msg::LocalizationMonitorResult>(
+      "localization_result", 50,
+      std::bind(&AlignmentFilterNode::localizationMonitorCallback, this, std::placeholders::_1));
+    local_odom_sub_ = this->create_subscription<nav_msgs::msg::Odometry>(
+      "local_odom", rclcpp::SensorDataQoS(),
+      std::bind(&AlignmentFilterNode::localOdomCallback, this, std::placeholders::_1));
+
+    if (publish_tf_) {
+      tf_buffer_ = std::make_unique<tf2_ros::Buffer>(this->get_clock());
+      tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
+      tf_broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(this);
+      tf_timer_ = this->create_wall_timer(
+        std::chrono::milliseconds(200),
+        std::bind(&AlignmentFilterNode::publishTransformTimer, this));
+    }
+
+    RCLCPP_INFO(this->get_logger(), "AlignmentFilterNode initialized");
+  }
+
+private:
+  void localizationMonitorCallback(
+    const robot_localization::msg::LocalizationMonitorResult::SharedPtr msg)
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    if (!msg->pose_global.header.frame_id.empty()) {
+      global_frame_ = msg->pose_global.header.frame_id;
+    }
+    if (!msg->pose_local.header.frame_id.empty()) {
+      local_frame_ = msg->pose_local.header.frame_id;
+    }
+
+    global_path_.poses.push_back(msg->pose_global);
+    local_path_.poses.push_back(msg->pose_local);
+
+    Eigen::Isometry3d global_pose = poseMsgToIsometry(msg->pose_global.pose);
+    Eigen::Isometry3d local_pose = poseMsgToIsometry(msg->pose_local.pose);
+    double timestamp_sec = rclcpp::Time(msg->pose_global.header.stamp).seconds();
+    double cumulative_length = msg->cumulative_length;
+    double trans_error = msg->float_array.empty() ? 0.0 : static_cast<double>(msg->float_array.front());
+
+    std::size_t removed = filter_.addMeasurement(global_pose, local_pose, timestamp_sec, trans_error,
+        cumulative_length);
+
+    if (removed > 0) {
+      if (global_path_.poses.size() > removed) {
+        global_path_.poses.erase(global_path_.poses.begin(), global_path_.poses.begin() + removed);
+      } else {
+        global_path_.poses.clear();
+      }
+
+      if (local_path_.poses.size() > removed) {
+        local_path_.poses.erase(local_path_.poses.begin(), local_path_.poses.begin() + removed);
+      } else {
+        local_path_.poses.clear();
+      }
+    }
+
+    if (filter_.hasSufficientData()) {
+      AlignmentResult result;
+      if (filter_.computeAlignment(result)) {
+        current_transform_ = result.transform;
+        updateTransformedPath(result.transformed_local, filter_.timestamps(), msg->pose_global.header);
+        publishPaths();
+      }
+    }
+  }
+
+  void localOdomCallback(const nav_msgs::msg::Odometry::SharedPtr msg)
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    Eigen::Vector3d position(msg->pose.pose.position.x, msg->pose.pose.position.y, msg->pose.pose.position.z);
+    Eigen::Quaterniond orientation = toEigenQuaternion(msg->pose.pose.orientation);
+    Eigen::Isometry3d current_pose = odomToSE3(position, orientation);
+    Eigen::Isometry3d transformed_pose = current_transform_ * current_pose;
+
+    auto transformed_msg = *msg;
+    transformed_msg.header.frame_id = global_frame_;
+    transformed_msg.pose.pose = toRosPose(transformed_pose);
+    transformed_msg.pose.covariance = {
+      1.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+      0.0, 1.0, 0.0, 0.0, 0.0, 0.0,
+      0.0, 0.0, 1.0, 0.0, 0.0, 0.0,
+      0.0, 0.0, 0.0, 0.1, 0.0, 0.0,
+      0.0, 0.0, 0.0, 0.0, 0.1, 0.0,
+      0.0, 0.0, 0.0, 0.0, 0.0, 0.1
+    };
+
+    odom_pub_->publish(transformed_msg);
+  }
+
+  void updateTransformedPath(
+    const std::vector<Eigen::Isometry3d> & transformed_local,
+    const std::vector<double> & time_stamps,
+    const std_msgs::msg::Header & header)
+  {
+    local_path_transformed_.poses.clear();
+    local_path_transformed_.header.frame_id = global_frame_;
+    local_path_transformed_.header.stamp = this->now();
+
+    for (std::size_t i = 0; i < transformed_local.size(); ++i) {
+      double stamp = (i < time_stamps.size()) ? time_stamps[i] : rclcpp::Time(header.stamp).seconds();
+      PoseStamped pose = se3ToPoseStamped(transformed_local[i], stamp, false);
+      local_path_transformed_.poses.push_back(
+        toRosPoseStamped(pose, global_frame_, secondsToTime(stamp)));
+    }
+  }
+
+  void publishPaths()
+  {
+    rclcpp::Time now = this->now();
+    global_path_.header.frame_id = global_frame_;
+    global_path_.header.stamp = now;
+    local_path_transformed_.header.stamp = now;
+
+    global_path_pub_->publish(global_path_);
+    local_path_transformed_pub_->publish(local_path_transformed_);
+  }
+
+  void publishTransformTimer()
+  {
+    if (!publish_tf_ || !tf_buffer_ || !tf_listener_ || !tf_broadcaster_) {
+      return;
+    }
+
+    try {
+      geometry_msgs::msg::TransformStamped latest_tf = tf_buffer_->lookupTransform(
+        local_frame_, "base_link", tf2::TimePointZero, tf2::durationFromSec(1.0));
+      geometry_msgs::msg::TransformStamped transform_msg;
+      transform_msg.header.stamp = latest_tf.header.stamp;
+      transform_msg.header.frame_id = global_frame_;
+      transform_msg.child_frame_id = local_frame_;
+
+      Eigen::Quaterniond q(current_transform_.linear());
+      q.normalize();
+      Eigen::Vector3d t = current_transform_.translation();
+
+      transform_msg.transform.translation.x = t.x();
+      transform_msg.transform.translation.y = t.y();
+      transform_msg.transform.translation.z = t.z();
+      transform_msg.transform.rotation.x = q.x();
+      transform_msg.transform.rotation.y = q.y();
+      transform_msg.transform.rotation.z = q.z();
+      transform_msg.transform.rotation.w = q.w();
+
+      tf_broadcaster_->sendTransform(transform_msg);
+    } catch (const tf2::TransformException & ex) {
+      RCLCPP_ERROR_THROTTLE(this->get_logger(), *this->get_clock(), 1000, "Error publishing transform: %s", ex.what());
+    }
+  }
+
+  bool publish_tf_;
+
+  rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr global_path_pub_;
+  rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr local_path_transformed_pub_;
+  rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr odom_pub_;
+
+  rclcpp::Subscription<robot_localization::msg::LocalizationMonitorResult>::SharedPtr
+    localization_result_sub_;
+  rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr local_odom_sub_;
+
+  std::unique_ptr<tf2_ros::Buffer> tf_buffer_;
+  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
+  std::shared_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
+  rclcpp::TimerBase::SharedPtr tf_timer_;
+
+  nav_msgs::msg::Path global_path_;
+  nav_msgs::msg::Path local_path_;
+  nav_msgs::msg::Path local_path_transformed_;
+
+  std::string global_frame_;
+  std::string local_frame_;
+
+  AlignmentFilter filter_;
+  Eigen::Isometry3d current_transform_;
+
+  std::mutex mutex_;
+};
+
+}  // namespace ais_robot_localization
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<ais_robot_localization::AlignmentFilterNode>());
+  rclcpp::shutdown();
+  return 0;
+}
+

--- a/src/localization_monitor.cpp
+++ b/src/localization_monitor.cpp
@@ -1,0 +1,80 @@
+#include "ais_robot_localization/localization_monitor.hpp"
+
+#include <algorithm>
+
+#include "ais_robot_localization/se3_algorithms.hpp"
+
+namespace ais_robot_localization
+{
+
+void checkCumulativeDistance(
+  std::vector<Eigen::Isometry3d> & local_poses,
+  std::vector<double> & local_times,
+  double & cumulative_distance,
+  double dist_cum_threshold,
+  std::size_t max_poses_threshold)
+{
+  while (((cumulative_distance > dist_cum_threshold) && local_poses.size() > 1) ||
+    local_poses.size() > max_poses_threshold)
+  {
+    double dist_removed = calculateEuclideanDistance(local_poses[0], local_poses[1]);
+    local_poses.erase(local_poses.begin());
+    local_times.erase(local_times.begin());
+    cumulative_distance -= dist_removed;
+  }
+}
+
+void cleanupGlobalOdomPoses(
+  std::vector<Eigen::Isometry3d> & global_poses,
+  std::vector<double> & global_times,
+  const std::vector<double> & local_times)
+{
+  if (local_times.empty()) {
+    return;
+  }
+  double oldest_local = local_times.front();
+  while (!global_times.empty() && global_times.front() < oldest_local) {
+    global_poses.erase(global_poses.begin());
+    global_times.erase(global_times.begin());
+  }
+}
+
+std::size_t findNearestTime(const std::vector<double> & times, double ref_time)
+{
+  if (times.empty()) {
+    return 0;
+  }
+  auto it = std::lower_bound(times.begin(), times.end(), ref_time);
+  if (it == times.begin()) {
+    return 0;
+  }
+  if (it == times.end()) {
+    return times.size() - 1;
+  }
+  std::size_t pos = static_cast<std::size_t>(std::distance(times.begin(), it));
+  double before = times[pos - 1];
+  double after = times[pos];
+  return (std::abs(after - ref_time) < std::abs(before - ref_time)) ? pos : pos - 1;
+}
+
+void findCorrespondingPoses(
+  const std::vector<double> & local_times,
+  const std::vector<Eigen::Isometry3d> & global_poses,
+  const std::vector<double> & global_times,
+  std::vector<Eigen::Isometry3d> & aligned_poses,
+  std::vector<double> & aligned_times)
+{
+  aligned_poses.clear();
+  aligned_times.clear();
+  if (local_times.empty() || global_times.empty()) {
+    return;
+  }
+  for (double ref_time : local_times) {
+    std::size_t idx = findNearestTime(global_times, ref_time);
+    aligned_poses.push_back(global_poses[idx]);
+    aligned_times.push_back(global_times[idx]);
+  }
+}
+
+}  // namespace ais_robot_localization
+

--- a/src/localization_monitor_node.cpp
+++ b/src/localization_monitor_node.cpp
@@ -1,0 +1,322 @@
+#include <algorithm>
+#include <functional>
+#include <limits>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+#include <nav_msgs/msg/path.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/float32_multi_array.hpp>
+#include <std_msgs/msg/header.hpp>
+
+#include "ais_robot_localization/localization_monitor.hpp"
+#include "ais_robot_localization/se3_algorithms.hpp"
+#include "robot_localization/msg/localization_monitor_result.hpp"
+
+namespace ais_robot_localization
+{
+namespace
+{
+
+double stampToDouble(const rclcpp::Time & stamp)
+{
+  return stamp.seconds();
+}
+
+rclcpp::Time secondsToTime(double seconds)
+{
+  return rclcpp::Time(static_cast<int64_t>(seconds * 1e9));
+}
+
+geometry_msgs::msg::PoseStamped toRosPoseStamped(
+  const PoseStamped & pose,
+  const std::string & frame_id,
+  const rclcpp::Time & stamp)
+{
+  geometry_msgs::msg::PoseStamped msg;
+  msg.header.frame_id = frame_id;
+  msg.header.stamp = stamp;
+  msg.pose.position.x = pose.position.x();
+  msg.pose.position.y = pose.position.y();
+  msg.pose.position.z = pose.position.z();
+  msg.pose.orientation.x = pose.orientation.x();
+  msg.pose.orientation.y = pose.orientation.y();
+  msg.pose.orientation.z = pose.orientation.z();
+  msg.pose.orientation.w = pose.orientation.w();
+  return msg;
+}
+
+Eigen::Quaterniond toEigenQuaternion(const geometry_msgs::msg::Quaternion & q)
+{
+  Eigen::Quaterniond eigen_q(q.w, q.x, q.y, q.z);
+  if (eigen_q.norm() == 0.0) {
+    return Eigen::Quaterniond::Identity();
+  }
+  eigen_q.normalize();
+  return eigen_q;
+}
+
+}  // namespace
+
+class LocalizationMonitorNode : public rclcpp::Node
+{
+public:
+  LocalizationMonitorNode()
+  : rclcpp::Node("localization_monitor"),
+    last_publish_time_sec_(0.0)
+  {
+    dist_cum_threshold_ = this->declare_parameter("dist_cum_threshold", 15.0);
+    publish_rate_ = this->declare_parameter("publish_rate", 1.0);
+    auto max_poses_param = this->declare_parameter<int>("max_poses_threshold", 500);
+    max_poses_threshold_ = max_poses_param < 0 ? 0 : static_cast<std::size_t>(max_poses_param);
+    time_based_ = this->declare_parameter("time_based", false);
+    publish_gnss_with_scaled_covariance_ =
+      this->declare_parameter("publish_gnss_with_scaled_covariance", false);
+    global_frame_ = this->declare_parameter<std::string>("global_frame", "map");
+    local_frame_ = this->declare_parameter<std::string>("local_frame", "odom");
+
+    feature_pub_ = this->create_publisher<std_msgs::msg::Float32MultiArray>("RPE_Values", 10);
+    global_path_pub_ = this->create_publisher<nav_msgs::msg::Path>("global_odom_path", 10);
+    local_path_pub_ = this->create_publisher<nav_msgs::msg::Path>("local_odom_path", 10);
+    localization_result_pub_ =
+      this->create_publisher<robot_localization::msg::LocalizationMonitorResult>(
+      "localization_result", 10);
+    gnss_with_scaled_covariance_pub_ =
+      this->create_publisher<nav_msgs::msg::Odometry>("gnss_with_scaled_covariance", 10);
+
+    auto qos = rclcpp::SensorDataQoS();
+    global_odom_sub_ = this->create_subscription<nav_msgs::msg::Odometry>(
+      "global_odom", qos,
+      std::bind(&LocalizationMonitorNode::globalOdomCallback, this, std::placeholders::_1));
+    local_odom_sub_ = this->create_subscription<nav_msgs::msg::Odometry>(
+      "local_odom", qos,
+      std::bind(&LocalizationMonitorNode::localOdomCallback, this, std::placeholders::_1));
+
+    RCLCPP_INFO(this->get_logger(), "LocalizationMonitorNode initialized");
+  }
+
+private:
+  void globalOdomCallback(const nav_msgs::msg::Odometry::SharedPtr msg)
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    Eigen::Vector3d position(msg->pose.pose.position.x, msg->pose.pose.position.y, msg->pose.pose.position.z);
+    Eigen::Quaterniond orientation = toEigenQuaternion(msg->pose.pose.orientation);
+    Eigen::Isometry3d pose = odomToSE3(position, orientation);
+
+    global_poses_.push_back(pose);
+    rclcpp::Time stamp(msg->header.stamp);
+    global_times_.push_back(stampToDouble(stamp));
+    newest_global_time_ = stamp;
+    global_frame_ = msg->header.frame_id;
+    newest_global_odom_ = *msg;
+    have_newest_global_odom_ = true;
+  }
+
+  void localOdomCallback(const nav_msgs::msg::Odometry::SharedPtr msg)
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    Eigen::Vector3d position(msg->pose.pose.position.x, msg->pose.pose.position.y, msg->pose.pose.position.z);
+    Eigen::Quaterniond orientation = toEigenQuaternion(msg->pose.pose.orientation);
+    Eigen::Isometry3d pose = odomToSE3(position, orientation);
+
+    double current_time = stampToDouble(rclcpp::Time(msg->header.stamp));
+    double min_interval = publish_rate_ > 0.0 ? 1.0 / publish_rate_ : 0.0;
+
+    if (!local_poses_.empty()) {
+      double dist = calculateEuclideanDistance(local_poses_.back(), pose);
+      if (!time_based_ && dist < 0.2) {
+        return;
+      }
+      if (time_based_ && min_interval > 0.0 && (current_time - last_publish_time_sec_) < min_interval) {
+        return;
+      }
+      cumulative_distance_ += dist;
+      cumulative_length_ += dist;
+    }
+
+    local_frame_ = msg->header.frame_id;
+    local_poses_.push_back(pose);
+    local_times_.push_back(current_time);
+
+    if (min_interval == 0.0 || (current_time - last_publish_time_sec_) >= min_interval) {
+      if (cumulative_distance_ > 1.0 || time_based_) {
+        processTrajectories(msg->header);
+        last_publish_time_sec_ = current_time;
+      }
+    }
+  }
+
+  void processTrajectories(const std_msgs::msg::Header & header)
+  {
+    if (local_poses_.empty() || global_poses_.empty()) {
+      publishResults(nullptr);
+      return;
+    }
+
+    checkCumulativeDistance(local_poses_, local_times_, cumulative_distance_, dist_cum_threshold_,
+      max_poses_threshold_);
+    cleanupGlobalOdomPoses(global_poses_, global_times_, local_times_);
+
+    if (global_poses_.empty()) {
+      publishResults(nullptr);
+      return;
+    }
+
+    std::vector<Eigen::Isometry3d> aligned_global;
+    std::vector<double> aligned_times;
+    findCorrespondingPoses(local_times_, global_poses_, global_times_, aligned_global, aligned_times);
+
+    if (aligned_global.empty()) {
+      publishResults(nullptr);
+      return;
+    }
+
+    global_poses_ = aligned_global;
+    global_times_ = aligned_times;
+
+    std::vector<Eigen::Isometry3d> local_aligned = local_poses_;
+    std::vector<Eigen::Isometry3d> reference = global_poses_;
+    alignTrajectories(local_aligned, reference);
+
+    updatePaths(reference, local_aligned, header);
+
+    RPEStats stats;
+    const RPEStats * stats_ptr = nullptr;
+    if (reference.size() >= 2 && local_aligned.size() >= 2 && cumulative_distance_ >= 2.0) {
+      stats = calculateRPE(reference, local_aligned);
+      stats_ptr = &stats;
+    }
+
+    publishResults(stats_ptr);
+
+    if (publish_gnss_with_scaled_covariance_ && have_newest_global_odom_) {
+      RCLCPP_WARN_ONCE(
+        this->get_logger(),
+        "Publishing GNSS odometry without covariance scaling; feature not yet implemented.");
+      gnss_with_scaled_covariance_pub_->publish(newest_global_odom_);
+    }
+  }
+
+  void updatePaths(
+    const std::vector<Eigen::Isometry3d> & reference,
+    const std::vector<Eigen::Isometry3d> & local_aligned,
+    const std_msgs::msg::Header & header)
+  {
+    global_path_.poses.clear();
+    local_path_.poses.clear();
+
+    for (std::size_t i = 0; i < reference.size(); ++i) {
+      PoseStamped global_pose = se3ToPoseStamped(reference[i], global_times_[i], false);
+      geometry_msgs::msg::PoseStamped global_msg =
+        toRosPoseStamped(global_pose, global_frame_, secondsToTime(global_times_[i]));
+      global_path_.poses.push_back(global_msg);
+    }
+
+    for (std::size_t i = 0; i < local_aligned.size(); ++i) {
+      PoseStamped local_pose = se3ToPoseStamped(local_aligned[i], local_times_[i], false);
+      geometry_msgs::msg::PoseStamped local_msg =
+        toRosPoseStamped(local_pose, global_frame_, header.stamp);
+      local_path_.poses.push_back(local_msg);
+    }
+
+    rclcpp::Time publish_stamp = newest_global_time_;
+    if (publish_stamp.nanoseconds() == 0 && !global_times_.empty()) {
+      publish_stamp = secondsToTime(global_times_.back());
+    }
+
+    global_path_.header.frame_id = global_frame_;
+    global_path_.header.stamp = publish_stamp;
+    local_path_.header.frame_id = global_frame_;
+    local_path_.header.stamp = publish_stamp;
+
+    global_path_pub_->publish(global_path_);
+    local_path_pub_->publish(local_path_);
+  }
+
+  void publishResults(const RPEStats * stats)
+  {
+    std_msgs::msg::Float32MultiArray feature_msg;
+    feature_msg.data.resize(4, std::numeric_limits<float>::infinity());
+
+    if (stats != nullptr) {
+      feature_msg.data[0] = static_cast<float>(stats->avg_trans);
+      feature_msg.data[1] = static_cast<float>(stats->avg_rot);
+      feature_msg.data[2] = static_cast<float>(stats->max_trans);
+      feature_msg.data[3] = static_cast<float>(stats->max_rot);
+    }
+
+    feature_pub_->publish(feature_msg);
+
+    if (global_poses_.empty() || local_poses_.empty() || local_times_.empty()) {
+      return;
+    }
+
+    std::size_t index = global_poses_.size() - 1;
+    PoseStamped global_pose = se3ToPoseStamped(global_poses_[index], local_times_[index], false);
+    PoseStamped local_pose = se3ToPoseStamped(local_poses_[index], local_times_[index], false);
+
+    robot_localization::msg::LocalizationMonitorResult result;
+    result.float_array = feature_msg.data;
+    auto result_stamp = secondsToTime(local_times_[index]);
+    result.pose_global =
+      toRosPoseStamped(global_pose, global_frame_, result_stamp);
+    result.pose_local =
+      toRosPoseStamped(local_pose, local_frame_, result_stamp);
+    result.cumulative_length = cumulative_length_;
+
+    localization_result_pub_->publish(result);
+  }
+
+  rclcpp::Publisher<std_msgs::msg::Float32MultiArray>::SharedPtr feature_pub_;
+  rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr global_path_pub_;
+  rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr local_path_pub_;
+  rclcpp::Publisher<robot_localization::msg::LocalizationMonitorResult>::SharedPtr
+    localization_result_pub_;
+  rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr gnss_with_scaled_covariance_pub_;
+
+  rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr global_odom_sub_;
+  rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr local_odom_sub_;
+
+  std::vector<Eigen::Isometry3d> global_poses_;
+  std::vector<double> global_times_;
+  std::vector<Eigen::Isometry3d> local_poses_;
+  std::vector<double> local_times_;
+
+  nav_msgs::msg::Path global_path_;
+  nav_msgs::msg::Path local_path_;
+
+  double cumulative_distance_{0.0};
+  double cumulative_length_{0.0};
+  double last_publish_time_sec_;
+
+  double dist_cum_threshold_{15.0};
+  double publish_rate_{1.0};
+  std::size_t max_poses_threshold_{500};
+  bool time_based_{false};
+  bool publish_gnss_with_scaled_covariance_{false};
+
+  std::string global_frame_;
+  std::string local_frame_;
+  rclcpp::Time newest_global_time_;
+  nav_msgs::msg::Odometry newest_global_odom_;
+  bool have_newest_global_odom_{false};
+
+  std::mutex mutex_;
+};
+
+}  // namespace ais_robot_localization
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<ais_robot_localization::LocalizationMonitorNode>());
+  rclcpp::shutdown();
+  return 0;
+}
+

--- a/src/se3_algorithms.cpp
+++ b/src/se3_algorithms.cpp
@@ -1,0 +1,257 @@
+#include "ais_robot_localization/se3_algorithms.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <numeric>
+
+namespace ais_robot_localization
+{
+
+Eigen::Isometry3d odomToSE3(const Eigen::Vector3d & position, const Eigen::Quaterniond & orientation)
+{
+  Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+  transform.linear() = orientation.toRotationMatrix();
+  transform.translation() = position;
+  return transform;
+}
+
+PoseStamped se3ToPoseStamped(const Eigen::Isometry3d & transform, double stamp, bool z_to_zero)
+{
+  PoseStamped pose;
+  pose.stamp = stamp;
+  pose.position = transform.translation();
+  if (z_to_zero) {
+    pose.position.z() = 0.0;
+  }
+  pose.orientation = Eigen::Quaterniond(transform.linear());
+  pose.orientation.normalize();
+  return pose;
+}
+
+double calculateEuclideanDistance(const Eigen::Isometry3d & pose1, const Eigen::Isometry3d & pose2)
+{
+  return (pose2.translation() - pose1.translation()).norm();
+}
+
+std::vector<double> gaussianWeights(const std::vector<double> & errors, double half_life)
+{
+  std::vector<double> weights;
+  weights.reserve(errors.size());
+
+  if (errors.empty()) {
+    return weights;
+  }
+
+  if (half_life <= 0.0) {
+    weights.assign(errors.size(), 1.0);
+    return weights;
+  }
+
+  double sigma = half_life / std::sqrt(2.0 * std::log(2.0));
+  if (!std::isfinite(sigma) || sigma <= 0.0) {
+    weights.assign(errors.size(), 1.0);
+    return weights;
+  }
+
+  for (double error : errors) {
+    double ratio = error / sigma;
+    weights.push_back(std::exp(-0.5 * ratio * ratio));
+  }
+
+  return weights;
+}
+
+void kabschAlgorithm(
+  const std::vector<Eigen::Vector3d> & src,
+  const std::vector<Eigen::Vector3d> & dst,
+  Eigen::Matrix3d & rotation,
+  Eigen::Vector3d & translation,
+  const std::vector<double> * weights)
+{
+  if (src.size() != dst.size() || src.empty()) {
+    rotation.setIdentity();
+    translation.setZero();
+    return;
+  }
+  std::vector<Eigen::Vector3d> src_pts = src;
+  std::vector<Eigen::Vector3d> dst_pts = dst;
+
+  Eigen::Vector3d centroid_src = Eigen::Vector3d::Zero();
+  Eigen::Vector3d centroid_dst = Eigen::Vector3d::Zero();
+
+  if (weights == nullptr) {
+    for (size_t i = 0; i < src_pts.size(); ++i) {
+      centroid_src += src_pts[i];
+      centroid_dst += dst_pts[i];
+    }
+    centroid_src /= static_cast<double>(src_pts.size());
+    centroid_dst /= static_cast<double>(dst_pts.size());
+  } else {
+    double weight_sum = std::accumulate(weights->begin(), weights->end(), 0.0);
+    if (weight_sum <= 0.0) {
+      rotation.setIdentity();
+      translation.setZero();
+      return;
+    }
+    for (size_t i = 0; i < src_pts.size(); ++i) {
+      double w = (*weights)[i] / weight_sum;
+      centroid_src += w * src_pts[i];
+      centroid_dst += w * dst_pts[i];
+    }
+  }
+
+  for (size_t i = 0; i < src_pts.size(); ++i) {
+    src_pts[i] -= centroid_src;
+    dst_pts[i] -= centroid_dst;
+  }
+
+  Eigen::Matrix3d H = Eigen::Matrix3d::Zero();
+  if (weights == nullptr) {
+    for (size_t i = 0; i < src_pts.size(); ++i) {
+      H += src_pts[i] * dst_pts[i].transpose();
+    }
+  } else {
+    for (size_t i = 0; i < src_pts.size(); ++i) {
+      H += (*weights)[i] * src_pts[i] * dst_pts[i].transpose();
+    }
+  }
+
+  Eigen::JacobiSVD<Eigen::Matrix3d> svd(H, Eigen::ComputeFullU | Eigen::ComputeFullV);
+  rotation = svd.matrixV() * svd.matrixU().transpose();
+  if (rotation.determinant() < 0) {
+    Eigen::Matrix3d V = svd.matrixV();
+    V.col(2) *= -1.0;
+    rotation = V * svd.matrixU().transpose();
+  }
+  translation = centroid_dst - rotation * centroid_src;
+}
+
+void makeSnake(std::vector<Eigen::Isometry3d> & trajectory, double fatness)
+{
+  if (trajectory.size() < 3) {
+    return;
+  }
+  Eigen::Vector4d translation_vec(0.0, 0.0, fatness, 1.0);
+  for (size_t i = 0; i + 1 < trajectory.size(); ++i) {
+    Eigen::Matrix4d rot = Eigen::Matrix4d::Identity();
+    rot.block<3, 3>(0, 0) = trajectory[i].linear();
+    Eigen::Vector4d offset = rot * translation_vec;
+    if (i % 2 == 0) {
+      offset *= -1.0;
+    }
+    trajectory[i].translation() += offset.head<3>();
+  }
+}
+
+Eigen::Isometry3d alignTrajectories(
+  std::vector<Eigen::Isometry3d> & trajectory,
+  const std::vector<Eigen::Isometry3d> & reference,
+  const std::vector<double> * weights)
+{
+  Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+  if (trajectory.size() != reference.size() || trajectory.empty()) {
+    return transform;
+  }
+
+  std::vector<Eigen::Isometry3d> ref_snake = reference;
+  makeSnake(trajectory);
+  makeSnake(ref_snake);
+
+  std::vector<Eigen::Vector3d> src_pts;
+  std::vector<Eigen::Vector3d> dst_pts;
+  src_pts.reserve(trajectory.size());
+  dst_pts.reserve(ref_snake.size());
+  for (size_t i = 0; i < trajectory.size(); ++i) {
+    src_pts.push_back(trajectory[i].translation());
+    dst_pts.push_back(ref_snake[i].translation());
+  }
+
+  Eigen::Matrix3d R;
+  Eigen::Vector3d t;
+  kabschAlgorithm(src_pts, dst_pts, R, t, weights);
+
+  transform.linear() = R;
+  transform.translation() = t;
+
+  for (auto & pose : trajectory) {
+    pose = transform * pose;
+  }
+  return transform;
+}
+
+RPEStats calculateRPE(
+  const std::vector<Eigen::Isometry3d> & reference,
+  const std::vector<Eigen::Isometry3d> & comparison)
+{
+  RPEStats stats;
+  if (reference.size() != comparison.size() || reference.size() < 2) {
+    return stats;
+  }
+
+  const size_t N = reference.size();
+
+  const Eigen::Isometry3d & P_Ga = reference.back();
+  const Eigen::Isometry3d & P_La = comparison.back();
+
+  std::vector<double> s_vals(N, 0.0);
+  for (size_t i = 1; i < N; ++i) {
+    double ds = (reference[i].translation() - reference[i - 1].translation()).norm();
+    s_vals[i] = s_vals[i - 1] + ds;
+  }
+  double total_length = s_vals.back() - s_vals.front();
+  if (total_length <= 1e-9) {
+    return stats;
+  }
+
+  auto relativeTransform = [](const Eigen::Isometry3d & A, const Eigen::Isometry3d & B) {
+      return A.inverse() * B;
+    };
+
+  auto se3_error = [&](const Eigen::Isometry3d & P_Gk, const Eigen::Isometry3d & P_Lk) {
+      Eigen::Isometry3d ref_rel = relativeTransform(P_Ga, P_Gk);
+      Eigen::Isometry3d comp_rel = relativeTransform(P_La, P_Lk);
+      return ref_rel.inverse() * comp_rel;
+    };
+
+  auto translationNorm = [](const Eigen::Isometry3d & T) {
+      return T.translation().norm();
+    };
+
+  auto rotationNorm = [](const Eigen::Isometry3d & T) {
+      Eigen::AngleAxisd aa(T.linear());
+      return std::abs(aa.angle());
+    };
+
+  double e_T = 0.0;
+  double e_R = 0.0;
+  double max_trans = 0.0;
+  double max_rot = 0.0;
+
+  for (size_t i = 0; i < N - 1; ++i) {
+    Eigen::Isometry3d E_k = se3_error(reference[i], comparison[i]);
+    Eigen::Isometry3d E_k1 = se3_error(reference[i + 1], comparison[i + 1]);
+
+    double t_err_k = translationNorm(E_k);
+    double t_err_k1 = translationNorm(E_k1);
+    double r_err_k = rotationNorm(E_k);
+    double r_err_k1 = rotationNorm(E_k1);
+
+    double ds = s_vals[i + 1] - s_vals[i];
+
+    e_T += ds * 0.5 * (t_err_k + t_err_k1);
+    e_R += ds * 0.5 * (r_err_k + r_err_k1);
+
+    max_trans = std::max({max_trans, t_err_k, t_err_k1});
+    max_rot = std::max({max_rot, r_err_k, r_err_k1});
+  }
+
+  stats.avg_trans = e_T / total_length;
+  stats.avg_rot = e_R / total_length;
+  stats.max_trans = max_trans;
+  stats.max_rot = max_rot;
+
+  return stats;
+}
+
+}  // namespace ais_robot_localization
+


### PR DESCRIPTION
## Summary
- add an RViz layout that highlights the alignment filter input, aligned odometry, and paths
- document the alignment layout alongside the monitoring visualization assets

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de7d7541c8832cb108d0c31c49f21d