### PR TITLE
Normalize stored global poses for yaw alignment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -407,6 +407,7 @@ install(DIRECTORY
 
 install(PROGRAMS
   scripts/navsat_preprocessing_node.py
+  scripts/navsat_preprocessing_node_ublox_livox.py
   scripts/localization_monitor_pipeline.sh
   DESTINATION lib/${PROJECT_NAME}
 )

--- a/include/ais_robot_localization/alignment_filter.hpp
+++ b/include/ais_robot_localization/alignment_filter.hpp
@@ -21,6 +21,8 @@ public:
   AlignmentFilter();
 
   void setMaxWindowLength(double length);
+  void setIgnoreGlobalYaw(bool ignore) {ignore_global_yaw_ = ignore;}
+  bool ignoreGlobalYaw() const {return ignore_global_yaw_;}
 
   std::size_t addMeasurement(
     const Eigen::Isometry3d & global_pose,
@@ -53,6 +55,7 @@ private:
 
   Eigen::Isometry3d current_transform_;
   double used_length_;
+  bool ignore_global_yaw_;
 };
 
 }  // namespace ais_robot_localization

--- a/include/ais_robot_localization/alignment_filter.hpp
+++ b/include/ais_robot_localization/alignment_filter.hpp
@@ -45,6 +45,7 @@ public:
 private:
   std::size_t cleanup();
   static double percentile(const std::vector<double> & values, double percent);
+  void alignGlobalYawWithLocal(const std::vector<Eigen::Isometry3d> & local_for_alignment);
 
   double max_window_length_;
   std::vector<Eigen::Isometry3d> global_poses_;

--- a/launch/alignment_filter_ublox_livox.launch.py
+++ b/launch/alignment_filter_ublox_livox.launch.py
@@ -1,0 +1,254 @@
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, SetEnvironmentVariable
+from launch.conditions import IfCondition
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description() -> LaunchDescription:
+    use_sim_time = LaunchConfiguration('use_sim_time')
+    monitor_params = LaunchConfiguration('monitor_params')
+    alignment_params = LaunchConfiguration('alignment_params')
+    navsat_params = LaunchConfiguration('navsat_params')
+    navsat_transform_params = LaunchConfiguration('navsat_transform_params')
+
+    global_odom_topic = LaunchConfiguration('global_odom_topic')
+    local_odom_topic = LaunchConfiguration('local_odom_topic')
+    monitor_result_topic = LaunchConfiguration('monitor_result_topic')
+    monitor_rpe_topic = LaunchConfiguration('monitor_rpe_topic')
+    monitor_global_path_topic = LaunchConfiguration('monitor_global_path_topic')
+    monitor_local_path_topic = LaunchConfiguration('monitor_local_path_topic')
+    scaled_gps_topic = LaunchConfiguration('scaled_gps_topic')
+
+    navsat_pre_input_topic = LaunchConfiguration('navsat_input_topic')
+    navsat_orientation_topic = LaunchConfiguration('navsat_orientation_topic')
+    navsat_output_topic = LaunchConfiguration('navsat_output_topic')
+    navsat_imu_topic = LaunchConfiguration('navsat_imu_topic')
+    navsat_fix_topic = LaunchConfiguration('navsat_fix_topic')
+
+    alignment_odom_topic = LaunchConfiguration('alignment_odom_topic')
+    alignment_global_path_topic = LaunchConfiguration('alignment_global_path_topic')
+    alignment_local_path_topic = LaunchConfiguration('alignment_local_path_topic')
+
+    start_navsat_preprocessing = LaunchConfiguration('start_navsat_preprocessing')
+    start_alignment_filter = LaunchConfiguration('start_alignment_filter')
+    start_navsat_transform = LaunchConfiguration('start_navsat_transform')
+    start_rviz = LaunchConfiguration('start_rviz')
+
+    declare_use_sim_time = DeclareLaunchArgument(
+        'use_sim_time', default_value='false',
+        description='Use simulation clock if true.')
+    declare_monitor_params = DeclareLaunchArgument(
+        'monitor_params',
+        default_value=PathJoinSubstitution([
+            FindPackageShare('ais_robot_localization'),
+            'params',
+            'localization_monitor.yaml',
+        ]),
+        description='Parameter file for the localization monitor node.')
+    declare_alignment_params = DeclareLaunchArgument(
+        'alignment_params',
+        default_value=PathJoinSubstitution([
+            FindPackageShare('ais_robot_localization'),
+            'params',
+            'alignment_filter.yaml',
+        ]),
+        description='Parameter file for the alignment filter node.')
+    declare_navsat_params = DeclareLaunchArgument(
+        'navsat_params',
+        default_value=PathJoinSubstitution([
+            FindPackageShare('ais_robot_localization'),
+            'params',
+            'navsat_preprocessing_ublox_livox.yaml',
+        ]),
+        description='Parameter file for the u-blox/Livox navsat preprocessing node.')
+    declare_navsat_transform_params = DeclareLaunchArgument(
+        'navsat_transform_params',
+        default_value=PathJoinSubstitution([
+            FindPackageShare('ais_robot_localization'),
+            'params',
+            'navsat_transform.yaml',
+        ]),
+        description='Parameter file for the navsat_transform_node.')
+
+    declare_global_odom = DeclareLaunchArgument(
+        'global_odom_topic',
+        default_value='localization/preprocessing/global_odom_fix_cov',
+        description='Globally referenced odometry topic to monitor.')
+    declare_local_odom = DeclareLaunchArgument(
+        'local_odom_topic',
+        default_value='localization/odometry/odom_lidar',
+        description='Locally referenced odometry topic to monitor and align.')
+    declare_monitor_result = DeclareLaunchArgument(
+        'monitor_result_topic',
+        default_value='localization/monitor/result',
+        description='Output topic for aggregated monitor statistics.')
+    declare_monitor_rpe = DeclareLaunchArgument(
+        'monitor_rpe_topic',
+        default_value='localization/monitor/RPE_Values',
+        description='Output topic for RPE feature vectors.')
+    declare_monitor_global_path = DeclareLaunchArgument(
+        'monitor_global_path_topic',
+        default_value='localization/monitor/global_reference_path',
+        description='Output topic for the global reference path.')
+    declare_monitor_local_path = DeclareLaunchArgument(
+        'monitor_local_path_topic',
+        default_value='localization/monitor/local_reference_path',
+        description='Output topic for the transformed local path.')
+    declare_scaled_gps = DeclareLaunchArgument(
+        'scaled_gps_topic',
+        default_value='localization/monitor/gnss_with_scaled_covariance',
+        description='Output topic for the GNSS message with scaled covariance.')
+
+    declare_navsat_input = DeclareLaunchArgument(
+        'navsat_input_topic',
+        default_value='localization/navsat/odometry/gps',
+        description='Input odometry topic for navsat preprocessing and transform nodes.')
+    declare_navsat_orientation = DeclareLaunchArgument(
+        'navsat_orientation_topic',
+        default_value='/livox/imu',
+        description='External orientation topic for the Livox IMU input.')
+    declare_navsat_output = DeclareLaunchArgument(
+        'navsat_output_topic',
+        default_value='localization/preprocessing/global_odom_fix_cov',
+        description='Output odometry topic for navsat preprocessing and navsat transform.')
+    declare_navsat_imu = DeclareLaunchArgument(
+        'navsat_imu_topic',
+        default_value='localization/preprocessing/global_orientation_fix_cov',
+        description='Output IMU topic containing the corrected orientation.')
+    declare_navsat_fix = DeclareLaunchArgument(
+        'navsat_fix_topic',
+        default_value='/ublox/fix',
+        description='Raw NavSatFix topic for the navsat transform node.')
+
+    declare_alignment_odom = DeclareLaunchArgument(
+        'alignment_odom_topic',
+        default_value='localization/alignment_filter/odom_map',
+        description='Output odometry topic for the alignment filter.')
+    declare_alignment_global_path = DeclareLaunchArgument(
+        'alignment_global_path_topic',
+        default_value='localization/alignment_filter/global_path',
+        description='Output topic for the alignment filter global path.')
+    declare_alignment_local_path = DeclareLaunchArgument(
+        'alignment_local_path_topic',
+        default_value='localization/alignment_filter/local_path',
+        description='Output topic for the transformed local path.')
+
+    declare_start_navsat_preprocessing = DeclareLaunchArgument(
+        'start_navsat_preprocessing',
+        default_value='true',
+        description='Start the navsat preprocessing node as part of the pipeline.')
+    declare_start_alignment_filter = DeclareLaunchArgument(
+        'start_alignment_filter',
+        default_value='true',
+        description='Start the alignment filter node as part of the pipeline.')
+    declare_start_navsat_transform = DeclareLaunchArgument(
+        'start_navsat_transform',
+        default_value='true',
+        description='Start the navsat_transform_node as part of the pipeline.')
+    declare_start_rviz = DeclareLaunchArgument(
+        'start_rviz',
+        default_value='true',
+        description='Request RViz to start when using the pipeline helper script.')
+
+    localization_monitor = Node(
+        package='ais_robot_localization',
+        executable='localization_monitor_node',
+        name='localization_monitor',
+        output='screen',
+        parameters=[monitor_params, {'use_sim_time': use_sim_time}],
+        remappings=[
+            ('global_odom', global_odom_topic),
+            ('local_odom', local_odom_topic),
+            ('global_odom_path', monitor_global_path_topic),
+            ('local_odom_path', monitor_local_path_topic),
+            ('localization_result', monitor_result_topic),
+            ('RPE_Values', monitor_rpe_topic),
+            ('gnss_with_scaled_covariance', scaled_gps_topic),
+        ],
+    )
+
+    alignment_filter = Node(
+        package='ais_robot_localization',
+        executable='alignment_filter_node',
+        name='alignment_filter',
+        output='screen',
+        parameters=[alignment_params, {'use_sim_time': use_sim_time}, {'ignore_global_yaw': True}],
+        remappings=[
+            ('local_odom', local_odom_topic),
+            ('localization_result', monitor_result_topic),
+            ('alignment_odometry', alignment_odom_topic),
+            ('alignment_global_path', alignment_global_path_topic),
+            ('alignment_local_path_transformed', alignment_local_path_topic),
+        ],
+        condition=IfCondition(start_alignment_filter),
+    )
+
+    navsat_preprocessing = Node(
+        package='ais_robot_localization',
+        executable='navsat_preprocessing_node_ublox_livox.py',
+        name='navsat_preprocessing_ublox_livox',
+        output='screen',
+        parameters=[navsat_params, {'use_sim_time': use_sim_time}],
+        remappings=[
+            ('localization/preprocessing/input/gps_odometry', navsat_pre_input_topic),
+            ('localization/preprocessing/input/imu', navsat_orientation_topic),
+            ('localization/preprocessing/output/odometry', navsat_output_topic),
+            ('localization/preprocessing/output/imu_with_fix_cov', navsat_imu_topic),
+        ],
+        condition=IfCondition(start_navsat_preprocessing),
+    )
+
+    navsat_transform = Node(
+        package='ais_robot_localization',
+        executable='navsat_transform_node',
+        name='navsat_transform_node',
+        output='screen',
+        parameters=[
+            navsat_transform_params,
+            {'use_sim_time': use_sim_time},
+            {'use_odometry_yaw': True},
+            {'publish_filtered_gps': True},
+            {'broadcast_cartesian_transform': True},
+        ],
+        remappings=[
+            ('odometry/filtered', alignment_odom_topic),
+            ('gps/fix', navsat_fix_topic),
+            ('odometry/gps', navsat_pre_input_topic),
+            ('gps/filtered', 'localization/navsat/filtered_gps'),
+        ],
+        condition=IfCondition(start_navsat_transform),
+    )
+
+    return LaunchDescription([
+        SetEnvironmentVariable('RCUTILS_COLORIZED_OUTPUT', '1'),
+        declare_use_sim_time,
+        declare_monitor_params,
+        declare_alignment_params,
+        declare_navsat_params,
+        declare_navsat_transform_params,
+        declare_global_odom,
+        declare_local_odom,
+        declare_monitor_result,
+        declare_monitor_rpe,
+        declare_monitor_global_path,
+        declare_monitor_local_path,
+        declare_scaled_gps,
+        declare_navsat_input,
+        declare_navsat_orientation,
+        declare_navsat_output,
+        declare_navsat_imu,
+        declare_navsat_fix,
+        declare_alignment_odom,
+        declare_alignment_global_path,
+        declare_alignment_local_path,
+        declare_start_navsat_preprocessing,
+        declare_start_alignment_filter,
+        declare_start_navsat_transform,
+        declare_start_rviz,
+        localization_monitor,
+        navsat_preprocessing,
+        alignment_filter,
+        navsat_transform,
+    ])

--- a/launch/navsat_preprocessing_ublox_livox.launch.py
+++ b/launch/navsat_preprocessing_ublox_livox.launch.py
@@ -1,0 +1,66 @@
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description() -> LaunchDescription:
+    use_sim_time = LaunchConfiguration('use_sim_time')
+    params_file = LaunchConfiguration('params_file')
+    gps_topic = LaunchConfiguration('gps_topic')
+    imu_topic = LaunchConfiguration('imu_topic')
+    odometry_output_topic = LaunchConfiguration('odometry_output_topic')
+    imu_output_topic = LaunchConfiguration('imu_output_topic')
+
+    declare_use_sim_time = DeclareLaunchArgument(
+        'use_sim_time', default_value='false',
+        description='Use simulation clock if true.')
+    declare_params_file = DeclareLaunchArgument(
+        'params_file',
+        default_value=PathJoinSubstitution([
+            FindPackageShare('ais_robot_localization'),
+            'params',
+            'navsat_preprocessing_ublox_livox.yaml',
+        ]),
+        description='Parameter file for the navsat preprocessing u-blox/Livox node.')
+    declare_gps_topic = DeclareLaunchArgument(
+        'gps_topic',
+        default_value='localization/navsat/odometry/gps',
+        description='Topic providing GNSS odometry messages.')
+    declare_imu_topic = DeclareLaunchArgument(
+        'imu_topic',
+        default_value='/livox/imu',
+        description='Topic providing Livox IMU measurements.')
+    declare_odometry_output = DeclareLaunchArgument(
+        'odometry_output_topic',
+        default_value='localization/preprocessing/global_odom_fix_cov',
+        description='Output topic for the fused global odometry.')
+    declare_imu_output = DeclareLaunchArgument(
+        'imu_output_topic',
+        default_value='localization/preprocessing/global_orientation_fix_cov',
+        description='Optional IMU topic with the corrected orientation.')
+
+    navsat_preprocessing = Node(
+        package='ais_robot_localization',
+        executable='navsat_preprocessing_node_ublox_livox.py',
+        name='navsat_preprocessing_ublox_livox',
+        output='screen',
+        parameters=[params_file, {'use_sim_time': use_sim_time}],
+        remappings=[
+            ('localization/preprocessing/input/gps_odometry', gps_topic),
+            ('localization/preprocessing/input/imu', imu_topic),
+            ('localization/preprocessing/output/odometry', odometry_output_topic),
+            ('localization/preprocessing/output/imu_with_fix_cov', imu_output_topic),
+        ],
+    )
+
+    return LaunchDescription([
+        declare_use_sim_time,
+        declare_params_file,
+        declare_gps_topic,
+        declare_imu_topic,
+        declare_odometry_output,
+        declare_imu_output,
+        navsat_preprocessing,
+    ])

--- a/params/alignment_filter.yaml
+++ b/params/alignment_filter.yaml
@@ -4,3 +4,4 @@ alignment_filter:
     global_frame: map
     local_frame: odom
     2D_mode: false
+    ignore_global_yaw: false

--- a/params/navsat_preprocessing_ublox_livox.yaml
+++ b/params/navsat_preprocessing_ublox_livox.yaml
@@ -1,0 +1,16 @@
+navsat_preprocessing_ublox_livox:
+  ros__parameters:
+    base_link_frame: base_link
+    use_external_heading: true
+    calculate_heading_from_trajectory: false
+    overwrite_covariance_matrix: false
+    heading_reference_length: 10.0
+    publish_imu_message_with_orientation: true
+    pose_covariance: [
+      1000.0, 0.0,   0.0,   0.0, 0.0, 0.0,
+      0.0,   1000.0, 0.0,   0.0, 0.0, 0.0,
+      0.0,   0.0,   1500.0, 0.0, 0.0, 0.0,
+      0.0,   0.0,      0.0, 0.5, 0.0, 0.0,
+      0.0,   0.0,      0.0, 0.0, 0.5, 0.0,
+      0.0,   0.0,      0.0, 0.0, 0.0, 0.5
+    ]

--- a/scripts/navsat_preprocessing_node_ublox_livox.py
+++ b/scripts/navsat_preprocessing_node_ublox_livox.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+import numpy as np
+if not hasattr(np, "float"):
+    np.float = float
+if not hasattr(np, "int"):
+    np.int = int
+
+
+from typing import Optional, Sequence
+
+import rclpy
+from rclpy.node import Node
+from rclpy.publisher import Publisher
+from rclpy.subscription import Subscription
+
+from geometry_msgs.msg import Quaternion
+from nav_msgs.msg import Odometry
+from sensor_msgs.msg import Imu
+
+import numpy as np
+import transforms3d.quaternions as quat
+
+
+
+
+class NavsatPreprocessingNode(Node):
+    """Fuse GNSS odometry with an externally provided heading source."""
+
+    def __init__(self) -> None:
+        super().__init__('navsat_preprocessing_node_ublox_livox')
+        self.get_logger().info('Initializing navsat preprocessing node for u-blox + Livox...')
+
+        if not self.has_parameter("use_sim_time"):
+            self.declare_parameter("use_sim_time", False)
+
+        self.use_sim_time = self.get_parameter("use_sim_time").get_parameter_value().bool_value
+
+        # Offset-Quaternion aus Parametern (ROS-Format [x,y,z,w])
+        self.q_off = self.declare_parameter(
+            "quat_offset", [0.0, 0.0, 1.0, 0.0]  # Default = Identität [0.0, 0.0, 0.0, 1.0]
+        ).value
+
+
+        self.base_link_frame = self.declare_parameter('base_link_frame', 'base_link').value
+        self.use_external_heading = self.declare_parameter('use_external_heading', True).value
+        self.calculate_heading_from_trajectory = self.declare_parameter(
+            'calculate_heading_from_trajectory', False).value
+        self.overwrite_covariance_matrix = self.declare_parameter(
+            'overwrite_covariance_matrix', False).value
+        param = self.declare_parameter('heading_reference_length', 10.0)
+        self.heading_reference_length = float(param.value)
+
+        self.publish_imu_message_with_orientation = self.declare_parameter(
+            'publish_imu_message_with_orientation', False).value
+
+        default_covariance = [
+            1000.0, 0.0,   0.0,   0.0, 0.0, 0.0,
+            0.0,   1000.0, 0.0,   0.0, 0.0, 0.0,
+            0.0,   0.0,   1500.0, 0.0, 0.0, 0.0,
+            0.0,   0.0,     0.0,  0.5, 0.0, 0.0,
+            0.0,   0.0,     0.0,  0.0, 0.5, 0.0,
+            0.0,   0.0,     0.0,  0.0, 0.0, 0.5,
+        ]
+        self.pose_covariance = self.declare_parameter(
+            'pose_covariance', default_covariance).value  # type: ignore[assignment]
+
+        qos = rclpy.qos.QoSProfile(depth=10)
+        self.odom_sub = self.create_subscription(
+            Odometry,
+            'localization/preprocessing/input/gps_odometry',
+            self.odom_callback,
+            qos)
+
+        self.orientation_sub: Optional[Subscription] = None
+        if self.use_external_heading:
+            self.orientation_sub = self.create_subscription(
+                Imu,
+                'localization/preprocessing/input/imu',
+                self.imu_callback,
+                qos)
+        elif self.calculate_heading_from_trajectory:
+            self.get_logger().error('calculate_heading_from_trajectory is not implemented yet')
+
+        self.odom_with_pose_pub = self.create_publisher(
+            Odometry, 'localization/preprocessing/output/odometry', 10)
+
+        self.imu_pub: Optional[Publisher] = None
+        if self.publish_imu_message_with_orientation:
+            self.imu_pub = self.create_publisher(
+                Imu, 'localization/preprocessing/output/imu_with_fix_cov', 10)
+
+        self.latest_odom: Optional[Odometry] = None
+        self.latest_orientation: Optional[Imu] = None
+
+    def odom_callback(self, msg: Odometry) -> None:
+        self.latest_odom = msg
+        if self.latest_orientation is None:
+            return
+        self.publish_odom_with_pose_and_covariance()
+
+    def imu_callback(self, msg: Imu) -> None:
+        self.latest_orientation = msg
+        if self.publish_imu_message_with_orientation and self.imu_pub is not None:
+            self.publish_imu_with_orientation()
+
+    
+    def quat_to_mat4(self, q: Quaternion) -> np.ndarray:
+        """Convert ROS Quaternion [x,y,z,w] to 4x4 rotation matrix."""
+        x, y, z, w = q.x, q.y, q.z, q.w
+        n = x*x + y*y + z*z + w*w
+        if n < 1e-16:
+            return np.eye(4)
+        s = 2.0 / n
+        xx, yy, zz = x*x*s, y*y*s, z*z*s
+        xy, xz, yz = x*y*s, x*z*s, y*z*s
+        wx, wy, wz = w*x*s, w*y*s, w*z*s
+        R = np.array([
+            [1.0 - (yy + zz), xy - wz,       xz + wy,       0.0],
+            [xy + wz,         1.0 - (xx + zz), yz - wx,     0.0],
+            [xz - wy,         yz + wx,       1.0 - (xx + yy), 0.0],
+            [0.0,             0.0,           0.0,           1.0],
+        ])
+        return R
+    
+    def mat4_to_quat(self, M: np.ndarray) -> Quaternion:
+        """Convert 4x4 (or 3x3) rotation matrix to ROS Quaternion [x,y,z,w]."""
+        m = M[:3, :3]
+        tr = np.trace(m)
+        if tr > 0.0:
+            S = np.sqrt(tr + 1.0) * 2.0
+            w = 0.25 * S
+            x = (m[2,1] - m[1,2]) / S
+            y = (m[0,2] - m[2,0]) / S
+            z = (m[1,0] - m[0,1]) / S
+        elif (m[0,0] > m[1,1]) and (m[0,0] > m[2,2]):
+            S = np.sqrt(1.0 + m[0,0] - m[1,1] - m[2,2]) * 2.0
+            w = (m[2,1] - m[1,2]) / S
+            x = 0.25 * S
+            y = (m[0,1] + m[1,0]) / S
+            z = (m[0,2] + m[2,0]) / S
+        elif m[1,1] > m[2,2]:
+            S = np.sqrt(1.0 + m[1,1] - m[0,0] - m[2,2]) * 2.0
+            w = (m[0,2] - m[2,0]) / S
+            x = (m[0,1] + m[1,0]) / S
+            y = 0.25 * S
+            z = (m[1,2] + m[2,1]) / S
+        else:
+            S = np.sqrt(1.0 + m[2,2] - m[0,0] - m[1,1]) * 2.0
+            w = (m[1,0] - m[0,1]) / S
+            x = (m[0,2] + m[2,0]) / S
+            y = (m[1,2] + m[2,1]) / S
+            z = 0.25 * S
+        return Quaternion(x=float(x), y=float(y), z=float(z), w=float(w))
+
+
+    def apply_static_transform(self, quaternion: Quaternion) -> Quaternion:
+        # Eingangs-Quaternion → Matrix
+        R_in = self.quat_to_mat4(quaternion)
+
+        q_off_ros = Quaternion(x=self.q_off[0], y=self.q_off[1], z=self.q_off[2], w=self.q_off[3])
+        R_off = self.quat_to_mat4(q_off_ros)
+
+        # Multiplizieren (lokale Rotation)
+        R_new = np.dot(R_in, R_off)
+
+        # Matrix zurück → Quaternion
+        return self.mat4_to_quat(R_new)
+
+
+
+    def publish_odom_with_pose_and_covariance(self) -> None:
+        if self.latest_odom is None or self.latest_orientation is None:
+            return
+
+        odom_with_pose = Odometry()
+        odom_with_pose.header = self.latest_odom.header
+        odom_with_pose.child_frame_id = self.base_link_frame
+        odom_with_pose.pose = self.latest_odom.pose
+
+        if self.overwrite_covariance_matrix:
+            odom_with_pose.pose.covariance = list(self.pose_covariance)
+
+        odom_with_pose.pose.pose.orientation = self.apply_static_transform(
+            self.latest_orientation.orientation)
+
+        self.odom_with_pose_pub.publish(odom_with_pose)
+
+    def publish_imu_with_orientation(self) -> None:
+        if self.latest_orientation is None or self.imu_pub is None:
+            return
+
+        imu_msg = Imu()
+        imu_msg.header = self.latest_orientation.header
+        imu_msg.orientation = self.latest_orientation.orientation
+        imu_msg.orientation_covariance = self._orientation_covariance_from_pose(self.pose_covariance)
+
+        self.imu_pub.publish(imu_msg)
+
+    @staticmethod
+    def _orientation_covariance_from_pose(covariance: Sequence[float]) -> Sequence[float]:
+        if len(covariance) >= 36:
+            return [
+                covariance[21], covariance[22], covariance[23],
+                covariance[27], covariance[28], covariance[29],
+                covariance[33], covariance[34], covariance[35],
+            ]
+        return [0.1, 0.0, 0.0, 0.0, 0.1, 0.0, 0.0, 0.0, 0.1]
+
+
+def main(args=None) -> None:
+    rclpy.init(args=args)
+    node = NavsatPreprocessingNode()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/alignment_filter.cpp
+++ b/src/alignment_filter.cpp
@@ -16,7 +16,8 @@ constexpr double kDefaultWindowLength = 150.0;
 AlignmentFilter::AlignmentFilter()
 : max_window_length_(kDefaultWindowLength),
   current_transform_(Eigen::Isometry3d::Identity()),
-  used_length_(0.0)
+  used_length_(0.0),
+  ignore_global_yaw_(false)
 {
 }
 
@@ -63,6 +64,18 @@ bool AlignmentFilter::computeAlignment(AlignmentResult & result)
   }
 
   std::vector<Eigen::Isometry3d> local_for_alignment = local_poses_;
+  if (ignore_global_yaw_) {
+    const std::size_t count = std::min(global_poses_.size(), local_for_alignment.size());
+    for (std::size_t i = 0; i < count; ++i) {
+      const Eigen::Matrix3d & global_rotation = global_poses_[i].linear();
+      const Eigen::Matrix3d & local_rotation = local_for_alignment[i].linear();
+      const double global_yaw = std::atan2(global_rotation(1, 0), global_rotation(0, 0));
+      const double local_yaw = std::atan2(local_rotation(1, 0), local_rotation(0, 0));
+      const double yaw_delta = local_yaw - global_yaw;
+      Eigen::Matrix3d yaw_alignment = Eigen::AngleAxisd(yaw_delta, Eigen::Vector3d::UnitZ()).toRotationMatrix();
+      global_poses_[i].linear() = yaw_alignment * global_poses_[i].linear();
+    }
+  }
   std::vector<double> weights = gaussianWeights(translational_errors_, percentile(translational_errors_, 25.0));
   const std::vector<double> * weights_ptr = nullptr;
   if (weights.size() == local_for_alignment.size()) {

--- a/src/alignment_filter.cpp
+++ b/src/alignment_filter.cpp
@@ -65,16 +65,7 @@ bool AlignmentFilter::computeAlignment(AlignmentResult & result)
 
   std::vector<Eigen::Isometry3d> local_for_alignment = local_poses_;
   if (ignore_global_yaw_) {
-    const std::size_t count = std::min(global_poses_.size(), local_for_alignment.size());
-    for (std::size_t i = 0; i < count; ++i) {
-      const Eigen::Matrix3d & global_rotation = global_poses_[i].linear();
-      const Eigen::Matrix3d & local_rotation = local_for_alignment[i].linear();
-      const double global_yaw = std::atan2(global_rotation(1, 0), global_rotation(0, 0));
-      const double local_yaw = std::atan2(local_rotation(1, 0), local_rotation(0, 0));
-      const double yaw_delta = local_yaw - global_yaw;
-      Eigen::Matrix3d yaw_alignment = Eigen::AngleAxisd(yaw_delta, Eigen::Vector3d::UnitZ()).toRotationMatrix();
-      global_poses_[i].linear() = yaw_alignment * global_poses_[i].linear();
-    }
+    alignGlobalYawWithLocal(local_for_alignment);
   }
   std::vector<double> weights = gaussianWeights(translational_errors_, percentile(translational_errors_, 25.0));
   const std::vector<double> * weights_ptr = nullptr;
@@ -135,6 +126,20 @@ double AlignmentFilter::percentile(const std::vector<double> & values, double pe
   double upper_value = sorted[static_cast<std::size_t>(upper_idx)];
 
   return lower_value + (upper_value - lower_value) * fraction;
+}
+
+void AlignmentFilter::alignGlobalYawWithLocal(const std::vector<Eigen::Isometry3d> & local_for_alignment)
+{
+  const std::size_t count = std::min(global_poses_.size(), local_for_alignment.size());
+  for (std::size_t i = 0; i < count; ++i) {
+    const Eigen::Matrix3d & global_rotation = global_poses_[i].linear();
+    const Eigen::Matrix3d & local_rotation = local_for_alignment[i].linear();
+    const double global_yaw = std::atan2(global_rotation(1, 0), global_rotation(0, 0));
+    const double local_yaw = std::atan2(local_rotation(1, 0), local_rotation(0, 0));
+    const double yaw_delta = local_yaw - global_yaw;
+    const Eigen::Matrix3d yaw_alignment = Eigen::AngleAxisd(yaw_delta, Eigen::Vector3d::UnitZ()).toRotationMatrix();
+    global_poses_[i].linear() = yaw_alignment * global_poses_[i].linear();
+  }
 }
 
 }  // namespace ais_robot_localization

--- a/src/alignment_filter.cpp
+++ b/src/alignment_filter.cpp
@@ -131,11 +131,13 @@ double AlignmentFilter::percentile(const std::vector<double> & values, double pe
 void AlignmentFilter::alignGlobalYawWithLocal(const std::vector<Eigen::Isometry3d> & local_for_alignment)
 {
   const std::size_t count = std::min(global_poses_.size(), local_for_alignment.size());
+  const Eigen::Matrix3d last_transform_rotation = current_transform_.linear();
   for (std::size_t i = 0; i < count; ++i) {
-    const Eigen::Matrix3d & global_rotation = global_poses_[i].linear();
-    const Eigen::Matrix3d & local_rotation = local_for_alignment[i].linear();
+    const Eigen::Matrix3d global_rotation = global_poses_[i].linear();
+    const Eigen::Matrix3d local_rotation_in_global =
+      last_transform_rotation * local_for_alignment[i].linear();
     const double global_yaw = std::atan2(global_rotation(1, 0), global_rotation(0, 0));
-    const double local_yaw = std::atan2(local_rotation(1, 0), local_rotation(0, 0));
+    const double local_yaw = std::atan2(local_rotation_in_global(1, 0), local_rotation_in_global(0, 0));
     const double yaw_delta = local_yaw - global_yaw;
     const Eigen::Matrix3d yaw_alignment = Eigen::AngleAxisd(yaw_delta, Eigen::Vector3d::UnitZ()).toRotationMatrix();
     global_poses_[i].linear() = yaw_alignment * global_poses_[i].linear();

--- a/src/alignment_filter_node.cpp
+++ b/src/alignment_filter_node.cpp
@@ -62,6 +62,19 @@ void projectTrajectoryToXYPlane(std::vector<Eigen::Isometry3d> & trajectory)
   }
 }
 
+void applyOrientations(nav_msgs::msg::Path & path, const std::vector<Eigen::Isometry3d> & poses)
+{
+  const std::size_t count = std::min(path.poses.size(), poses.size());
+  for (std::size_t i = 0; i < count; ++i) {
+    Eigen::Quaterniond orientation(poses[i].linear());
+    orientation.normalize();
+    path.poses[i].pose.orientation.x = orientation.x();
+    path.poses[i].pose.orientation.y = orientation.y();
+    path.poses[i].pose.orientation.z = orientation.z();
+    path.poses[i].pose.orientation.w = orientation.w();
+  }
+}
+
 Eigen::Isometry3d poseMsgToIsometry(const geometry_msgs::msg::Pose & pose_msg)
 {
   Eigen::Vector3d position(pose_msg.position.x, pose_msg.position.y, pose_msg.position.z);
@@ -116,10 +129,13 @@ public:
   : rclcpp::Node("alignment_filter_node"),
     publish_tf_(this->declare_parameter("publish_tf", true)),
     two_d_mode_(this->declare_parameter("2D_mode", false)),
+    ignore_global_yaw_(this->declare_parameter("ignore_global_yaw", false)),
     current_transform_(Eigen::Isometry3d::Identity())
   {
     global_frame_ = this->declare_parameter<std::string>("global_frame", "map");
     local_frame_ = this->declare_parameter<std::string>("local_frame", "odom");
+
+    filter_.setIgnoreGlobalYaw(ignore_global_yaw_);
 
     global_path_pub_ = this->create_publisher<nav_msgs::msg::Path>("alignment_global_path", 10);
     local_path_transformed_pub_ =
@@ -192,6 +208,9 @@ private:
           projectTrajectoryToXYPlane(result.transformed_local);
         }
         current_transform_ = transform_to_use;
+        if (ignore_global_yaw_) {
+          applyOrientations(global_path_, filter_.globalPoses());
+        }
         updateTransformedPath(result.transformed_local, filter_.timestamps(), msg->pose_global.header);
         publishPaths();
       }
@@ -287,6 +306,7 @@ private:
 
   bool publish_tf_;
   bool two_d_mode_;
+  bool ignore_global_yaw_;
 
   rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr global_path_pub_;
   rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr local_path_transformed_pub_;


### PR DESCRIPTION
## Summary
- rotate the filter's stored global poses in place when ignore_global_yaw is enabled
- drop the extra adjusted_global storage from AlignmentResult
- reuse the filter's cached global poses to stamp the published path orientations

## Testing
- not run (colcon not available in environment)

------
https://chatgpt.com/codex/tasks/task_e_68f0a93d92c4832c81857ba5d808962d